### PR TITLE
OT169-23 Endpoint datos públicos de la organización

### DIFF
--- a/src/main/java/com/alkemy/ong/controller/OrganizationController.java
+++ b/src/main/java/com/alkemy/ong/controller/OrganizationController.java
@@ -1,0 +1,23 @@
+package com.alkemy.ong.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.alkemy.ong.dto.OrganizationDto;
+import com.alkemy.ong.service.impl.OrganizationService;
+
+@RestController
+@RequestMapping("/organization")
+public class OrganizationController {
+	
+	@Autowired
+	private OrganizationService service;
+	
+	@GetMapping("/public") 
+	public OrganizationDto getPublicInfo() {
+		return service.getPublicInfo();
+	}
+
+}

--- a/src/main/java/com/alkemy/ong/dto/OrganizationDto.java
+++ b/src/main/java/com/alkemy/ong/dto/OrganizationDto.java
@@ -1,0 +1,45 @@
+package com.alkemy.ong.dto;
+
+public class OrganizationDto {
+	
+	private String name;
+	private String image; 
+	private Integer phone;
+	private String address;
+	
+	public OrganizationDto() {
+		// TODO Auto-generated constructor stub
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getImage() {
+		return image;
+	}
+
+	public void setImage(String image) {
+		this.image = image;
+	}
+
+	public Integer getPhone() {
+		return phone;
+	}
+
+	public void setPhone(Integer phone) {
+		this.phone = phone;
+	}
+
+	public String getAddress() {
+		return address;
+	}
+
+	public void setAddress(String address) {
+		this.address = address;
+	}
+}

--- a/src/main/java/com/alkemy/ong/entities/OrganizationMock.java
+++ b/src/main/java/com/alkemy/ong/entities/OrganizationMock.java
@@ -1,0 +1,53 @@
+package com.alkemy.ong.entities;
+
+public class OrganizationMock {
+	private String name;
+	private String image;
+	private Integer phone;
+	private String address;
+	private int secretValue;
+	
+	public OrganizationMock() {
+		// TODO Auto-generated constructor stub
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getImage() {
+		return image;
+	}
+
+	public void setImage(String image) {
+		this.image = image;
+	}
+
+	public Integer getPhone() {
+		return phone;
+	}
+
+	public void setPhone(Integer phone) {
+		this.phone = phone;
+	}
+
+	public String getAddress() {
+		return address;
+	}
+
+	public void setAddress(String address) {
+		this.address = address;
+	}
+	
+	public int getSecretValue() {
+		return secretValue;
+	}
+	
+	public void setSecretValue(int secretValue) {
+		this.secretValue = secretValue;
+	}
+}

--- a/src/main/java/com/alkemy/ong/service/IOrganizationService.java
+++ b/src/main/java/com/alkemy/ong/service/IOrganizationService.java
@@ -1,0 +1,8 @@
+package com.alkemy.ong.service;
+
+import com.alkemy.ong.dto.OrganizationDto;
+
+public interface IOrganizationService {
+	
+	OrganizationDto getPublicInfo();
+}

--- a/src/main/java/com/alkemy/ong/service/impl/OrganizationService.java
+++ b/src/main/java/com/alkemy/ong/service/impl/OrganizationService.java
@@ -1,0 +1,25 @@
+package com.alkemy.ong.service.impl;
+
+import org.springframework.stereotype.Service;
+
+import com.alkemy.ong.dto.OrganizationDto;
+import com.alkemy.ong.entities.OrganizationMock;
+import com.alkemy.ong.service.IOrganizationService;
+import com.alkemy.ong.utils.Mapper;
+
+@Service
+public class OrganizationService implements IOrganizationService {
+
+	@Override
+	public OrganizationDto getPublicInfo() {
+		OrganizationMock organization = new OrganizationMock();
+		organization.setName("Organization Name");
+		organization.setImage("Organization.jpg");
+		organization.setPhone(Integer.valueOf(123456789));
+		organization.setAddress("Organization address");
+		organization.setSecretValue(1);
+		
+		return Mapper.mapToDto(organization);
+	}
+	
+}

--- a/src/main/java/com/alkemy/ong/utils/Mapper.java
+++ b/src/main/java/com/alkemy/ong/utils/Mapper.java
@@ -1,0 +1,17 @@
+package com.alkemy.ong.utils;
+
+import com.alkemy.ong.dto.OrganizationDto;
+import com.alkemy.ong.entities.OrganizationMock;
+
+public class Mapper {
+	
+	public static OrganizationDto mapToDto(OrganizationMock organizationMock) {
+		OrganizationDto dto = new OrganizationDto();
+		dto.setName(organizationMock.getName());
+		dto.setImage(organizationMock.getImage());
+		dto.setPhone(organizationMock.getPhone());
+		dto.setAddress(organizationMock.getAddress());
+		return dto;
+	}
+	
+}


### PR DESCRIPTION
**Endpoint datos públicos de la organización**

1. Organization Controller
- Expuse endpoint /organization para todos los métodos de controlador.
- Cree @GetMapping con endpoint /public para recuperar los datos publicos de la organización a partir de un servicio.

2. Organization Service
- Contiene método getPublicInfo() que devuelve solamente los datos públicos de la organización en un OrganizationDto.

3. Mapper
- Mapea un objeto OrganizationMock (en el futuro deberá ser un Organization) a un OrganizationDto con sus campos publicos.

4. OrganizationDto
- Contenedor que solo muestra las propiedades _name_, _image_, phone y _address_

5. OrganizationMock
- Clase para probar la funcionalidad del Mapper, deberá ser reemplazada por la clase Organization una vez esté en main.