### PR TITLE
OT169-33 Validate if user is allowed to certains endpoints

### DIFF
--- a/src/main/java/com/alkemy/ong/service/UserService.java
+++ b/src/main/java/com/alkemy/ong/service/UserService.java
@@ -1,6 +1,7 @@
 package com.alkemy.ong.service;
 
 import com.alkemy.ong.entity.User;
+import com.amazonaws.services.pinpoint.model.ForbiddenException;
 import org.springframework.http.ResponseEntity;
 
 import java.util.Map;
@@ -14,4 +15,6 @@ public interface UserService {
     ResponseEntity<?> updatePartialInfo(String id, Map<Object, Object> fields);
 
     ResponseEntity<?> getAllUser();
+
+    void isUserAllowed(String id) throws ForbiddenException;
 }


### PR DESCRIPTION
Criterios de aceptación: 

Se utilizará para proteger endpoints que son solo para el usuario actual. Deberá verificar el parámetro ID y compararlo con el ID del usuario enviado en el token JWT, caso contrario, devolver error 403. Sin embargo, si el usuario que es enviado en el token es administrador, si le permitirá continuar.

***RESUMEN***

Se creo el método "isUserAllowed" que recibe el id del usuario pasado como Path Variable y lo compara con el recibido por el jwt. Si el usuario no tiene rol de administrador y no es el usuario actual (es decir, no coincide el usuario pasado como variable como el usuario autenticado) se restringe el acceso y se devuelve un 403 indicando que el usuario no tiene permiso para realizar dicha acción.