### PR TITLE
OT169-77 PUT comment´s endpoint added

### DIFF
--- a/src/main/java/com/alkemy/ong/controller/CommentController.java
+++ b/src/main/java/com/alkemy/ong/controller/CommentController.java
@@ -27,4 +27,9 @@ public class CommentController {
     public ResponseEntity<Void> addComment(@Valid @RequestBody CommentRequestDto commentRequestDto){
         return service.addComment(commentRequestDto);
     }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> putComment(@PathVariable String id, @RequestBody @Valid CommentRequestDto commentRequestDto){
+        return service.putComment(id,commentRequestDto);
+    }
 }

--- a/src/main/java/com/alkemy/ong/service/ICommentService.java
+++ b/src/main/java/com/alkemy/ong/service/ICommentService.java
@@ -3,6 +3,8 @@ package com.alkemy.ong.service;
 import com.alkemy.ong.dto.CommentRequestDto;
 import com.alkemy.ong.dto.CommentResponseDto;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 
@@ -10,4 +12,6 @@ public interface ICommentService {
     List<CommentResponseDto> getAllComments();
 
     ResponseEntity<Void> addComment(CommentRequestDto commentRequestDto);
+
+    ResponseEntity<Void> putComment(@PathVariable String id, @RequestBody CommentRequestDto commentRequestDto);
 }

--- a/src/main/java/com/alkemy/ong/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/CommentServiceImpl.java
@@ -68,8 +68,8 @@ public class CommentServiceImpl implements ICommentService {
 
     @Override
     public ResponseEntity<Void> putComment(String id, CommentRequestDto commentRequestDto) {
-        Optional<User> optionalUser = optionalUser = userRepository.findById(commentRequestDto.getUser_id());//check if new user id exits
-        Optional<News> optionalNews = optionalNews = newsRepository.findById(commentRequestDto.getPost_id());//check if new news id exists
+        Optional<User> optionalUser = userRepository.findById(commentRequestDto.getUser_id());//check if new user id exits
+        Optional<News> optionalNews = newsRepository.findById(commentRequestDto.getPost_id());//check if new news id exists
         Optional<Comment> optionalComment = commentRepository.findById(id);//check if the comment exits
 
         if(optionalComment.isEmpty() || optionalUser.isEmpty() || optionalNews.isEmpty()) {

--- a/src/main/java/com/alkemy/ong/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/CommentServiceImpl.java
@@ -2,6 +2,7 @@ package com.alkemy.ong.service.impl;
 
 import com.alkemy.ong.dto.CommentRequestDto;
 import com.alkemy.ong.dto.CommentResponseDto;
+import com.alkemy.ong.entity.Category;
 import com.alkemy.ong.entity.Comment;
 import com.alkemy.ong.entity.News;
 import com.alkemy.ong.entity.User;
@@ -9,9 +10,11 @@ import com.alkemy.ong.repository.CommentRepository;
 import com.alkemy.ong.repository.NewsRepository;
 import com.alkemy.ong.repository.UserRepository;
 import com.alkemy.ong.service.ICommentService;
+import com.alkemy.ong.service.UserService;
 import com.alkemy.ong.utils.Mapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
@@ -36,6 +39,9 @@ public class CommentServiceImpl implements ICommentService {
     @Autowired
     private CommentRepository commentRepository;
 
+    @Autowired
+    private UserService userService;
+
     @Override
     public List<CommentResponseDto> getAllComments() {
         return repository.findAll(Sort.by("timestamp").descending())
@@ -59,4 +65,19 @@ public class CommentServiceImpl implements ICommentService {
 
         return ResponseEntity.ok().build();
     }
+
+    @Override
+    public ResponseEntity<Void> putComment(String id, CommentRequestDto commentRequestDto) {
+        Optional<User> optionalUser = optionalUser = userRepository.findById(commentRequestDto.getUser_id());//check if new user id exits
+        Optional<News> optionalNews = optionalNews = newsRepository.findById(commentRequestDto.getPost_id());//check if new news id exists
+        Optional<Comment> optionalComment = commentRepository.findById(id);//check if the comment exits
+
+        if(optionalComment.isEmpty() || optionalUser.isEmpty() || optionalNews.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();//return 404 if the given id comment,id news or id user does not exist
+        }
+
+        userService.isUserAllowed(optionalComment.get().getUser_id().getId()); //return 403 if the user is not the one who wrote the comment or authenticated user has no admin role
+        commentRepository.save(new Mapper().mapFromDto(commentRequestDto,optionalComment.get(),optionalUser.get(),optionalNews.get()));
+        return ResponseEntity.status(HttpStatus.OK).build();
+        }
 }


### PR DESCRIPTION
Criterios de aceptación:
COMO usuario
QUIERO actualizar un comentario propio
PARA mantener la información actualizada

Criterios de aceptación:
PUT /comments/:id - Deberá validar la existencia del comentario en base a su id. Solamente podrán editar un comentario el usuario que lo realizó o un administrador. Deberá devolver un código de error 404 si el comentario no existe, o 403 si no tiene permiso para modificarlo.

**RESUMEN**

*Comment Controller
-> Se creo el endpoint para realizar el PUT, que recibe el id del comentario como Path Variable y un CommentRequestDto (body, user_id y post_id) valido.

*ICommentsService
->Se agrego el método "putComment" a la interfaz

*CommentServiceImpl
->Se implemento el metodo "putComment" que recibe el id del comentario a modificar y un CommentRequestDto. Valida que los nuevos id de user y post existan previamente, y que el id del comentario a modificar también exista.  Luego llama al método del userService "isUserAllowed" que le paso el id del creador del comentario para que verifique si el usuario autenticado es administrador o es el creador del mismo. Es caso de que sea correcto lo deja pasar, sino tira un código de estado 403 prohibido. Finalmente, guarda los cambios en el comentario y devuelve un código 200 indicando que finalizo con éxito.
