### PR TITLE
OT169-FMC: Adding RequestBody to Categories Controller

### DIFF
--- a/src/main/java/com/alkemy/ong/controller/CategoriesController.java
+++ b/src/main/java/com/alkemy/ong/controller/CategoriesController.java
@@ -25,13 +25,12 @@ public class CategoriesController {
 	}
 
 	@GetMapping("/{id}") // OT169-41
-	public ResponseEntity<Category> getById(@PathVariable(name = "id", required = false) String id, @RequestBody Category category) {
+	public ResponseEntity<Category> getById(@PathVariable(name = "id", required = false) String id) {
 		if (categoryService.existsById(id)) {// If the ID corresponds to an Category, returns it
 			return new ResponseEntity<Category>(categoryService.getById(id), HttpStatus.OK);
 		}
 		// If the ID doesn't corresponds to an Category, sends an error
 		return new ResponseEntity<Category>(HttpStatus.NOT_FOUND);
-
 	}
 
 	@PostMapping("/") // OT169-42

--- a/src/main/java/com/alkemy/ong/controller/CategoriesController.java
+++ b/src/main/java/com/alkemy/ong/controller/CategoriesController.java
@@ -25,7 +25,7 @@ public class CategoriesController {
 	}
 
 	@GetMapping("/{id}") // OT169-41
-	public ResponseEntity<Category> getById(@PathVariable(name = "id", required = false) String id) {
+	public ResponseEntity<Category> getById(@PathVariable(name = "id", required = false) String id, @RequestBody Category category) {
 		if (categoryService.existsById(id)) {// If the ID corresponds to an Category, returns it
 			return new ResponseEntity<Category>(categoryService.getById(id), HttpStatus.OK);
 		}


### PR DESCRIPTION
This PR fixes a bug, the getById endpoint of the CategoriesController doesn't work because it doesn't had the RequestBody , and this PR adds it.