### PR TITLE
Agregar paginación a Novedades OT169-81

### DIFF
--- a/src/main/java/com/alkemy/ong/controller/NewsController.java
+++ b/src/main/java/com/alkemy/ong/controller/NewsController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
 import javax.validation.Valid;
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/news")
@@ -28,8 +30,8 @@ public class NewsController {
     @GetMapping("/{id}")
     public ResponseEntity<NewsDto> getNewsById(@PathVariable String id) throws Exception {
         try{
-            newsService.getNewsById(id);
-            return ResponseEntity.status(HttpStatus.OK).build();
+            NewsDto newsDto= newsService.getNewsById(id);
+            return ResponseEntity.status(HttpStatus.OK).body(newsDto);
         } catch (Exception e){
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
@@ -52,14 +54,25 @@ public class NewsController {
        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-
-
-
-
-
-
-
+    @GetMapping("/pages")
+    public ResponseEntity<Map<String, Object>> getAllPage(@RequestParam(defaultValue = "0") Integer page){
+        Map<String, Object> news = new HashMap<>();
+        try {
+            news = newsService.getAllPages(page);
+            return new ResponseEntity<>(news, HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(null, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
+
+
+
+
+
+
+
+
+}
 
 
 

--- a/src/main/java/com/alkemy/ong/repository/NewsRepository.java
+++ b/src/main/java/com/alkemy/ong/repository/NewsRepository.java
@@ -1,11 +1,21 @@
 package com.alkemy.ong.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.alkemy.ong.entity.News;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.LinkedHashMap;
+import java.util.List;
 
 @Repository
 public interface NewsRepository extends JpaRepository<News, String>{
 
+    @Query(value="SELECT id, name, content, image from News",nativeQuery=true)
+    Page<List<LinkedHashMap>> findPage(Pageable paging);
+
+    Page<News> findAll(Pageable pageable);
 }

--- a/src/main/java/com/alkemy/ong/service/NewsService.java
+++ b/src/main/java/com/alkemy/ong/service/NewsService.java
@@ -4,6 +4,8 @@ package com.alkemy.ong.service;
 import com.alkemy.ong.dto.NewsDto;
 import com.alkemy.ong.entity.News;
 
+import java.util.Map;
+
 public  interface  NewsService {
 
      NewsDto save(NewsDto newsDto);
@@ -15,4 +17,6 @@ public  interface  NewsService {
     NewsDto updateNews(String id, NewsDto newsDto);
 
     News getOne(String id) throws Exception;
+
+    Map<String, Object> getAllPages(Integer page) throws Exception;
 }


### PR DESCRIPTION
COMO usuario
QUIERO visualizar los resultados de Novedades paginados
PARA aumentar la velocidad de respuesta

Criterios de aceptación:Cuando se realice la petición para listar, 
los resultados deberán paginarse de a 10.
 En la respuesta, se deberán mostrar los resultados y las urls para la página anterior y siguiente 
(si corresponden).
 La página actual se obtendrá del parámetro de query ?page

ADEMAS:

- Se modifico el GET del controller de news para que devuelva un body.