### PR TITLE
OT169-83: Agregar paginación a Testimonios

### DIFF
--- a/src/main/java/com/alkemy/ong/controller/TestimonialController.java
+++ b/src/main/java/com/alkemy/ong/controller/TestimonialController.java
@@ -12,6 +12,8 @@ import org.springframework.web.server.ResponseStatusException;
 
 
 import javax.validation.Valid;
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/testimonials")
@@ -43,8 +45,17 @@ public class TestimonialController {
         }   catch (Exception e){
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }
+    }
 
-
+    @GetMapping("/pages")
+    public ResponseEntity<Map<String, Object>> getAllPage(@RequestParam(defaultValue = "0") int page) {
+        Map<String, Object> testimonial = new HashMap<>();
+        try {
+            testimonial = testimonialService.getAllPages(page);
+            return new ResponseEntity<>(testimonial, HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(null, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
 

--- a/src/main/java/com/alkemy/ong/repository/TestimonialRepository.java
+++ b/src/main/java/com/alkemy/ong/repository/TestimonialRepository.java
@@ -1,12 +1,19 @@
 package com.alkemy.ong.repository;
 
 import com.alkemy.ong.entity.Testimonial;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.util.UUID;
+import java.util.LinkedHashMap;
+import java.util.List;
 
 @Repository
 public interface TestimonialRepository extends JpaRepository<Testimonial, String> {
+
+    @Query(value="SELECT id, name, content, image FROM testimonials",nativeQuery=true)
+    Page<List<LinkedHashMap>> findPage(Pageable pageable);
 
 }

--- a/src/main/java/com/alkemy/ong/service/TestimonialService.java
+++ b/src/main/java/com/alkemy/ong/service/TestimonialService.java
@@ -2,6 +2,8 @@ package com.alkemy.ong.service;
 
 import com.alkemy.ong.dto.TestimonialDto;
 
+import java.util.Map;
+
 public interface TestimonialService {
 
      TestimonialDto save(TestimonialDto testimonialDto);
@@ -9,5 +11,7 @@ public interface TestimonialService {
     void delete(String id);
 
     TestimonialDto updateTestimonials(TestimonialDto testimonialDto, String id);
+
+    Map<String, Object> getAllPages (Integer page) throws Exception;
 
 }

--- a/src/main/java/com/alkemy/ong/service/impl/TestimonialServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/TestimonialServiceImpl.java
@@ -7,11 +7,14 @@ import com.alkemy.ong.service.TestimonialService;
 import com.alkemy.ong.utils.Mapper;
 import com.amazonaws.services.simplesystemsmanagement.model.ParameterNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.Optional;
+import java.util.*;
 
 import java.util.Optional;
 
@@ -57,5 +60,41 @@ public class TestimonialServiceImpl implements TestimonialService {
             throw new ParameterNotFoundException("");
         }
     }
+    public Map<String, Object> getAllPages (Integer page) throws Exception {
+        Integer size = 10;
+        try {
+            List<List<LinkedHashMap>> testimonialList = new ArrayList<List<LinkedHashMap>>();
+
+            Pageable paging = PageRequest.of(page, size);
+            String url = "/testimonials/pages?page=";
+
+            Page<List<LinkedHashMap>> pagedTestimonials;
+            pagedTestimonials = testimonialRepository.findPage(paging);
+
+            testimonialList = pagedTestimonials.getContent();
+            Map<String, Object> response = new LinkedHashMap<>();
+            response.put("Total Items", pagedTestimonials.getTotalElements());
+            response.put("Total Pages", pagedTestimonials.getTotalPages());
+            response.put("Current Page", pagedTestimonials.getNumber());
+
+            if (pagedTestimonials.getNumber() == pagedTestimonials.getTotalPages() - 1) {
+                response.put("Next Page", "This is the last page");
+            } else {
+                response.put("Next Page", url.concat(String.valueOf(pagedTestimonials.getNumber() + 1)));
+            }
+            if (pagedTestimonials.getNumber() == 0) {
+                response.put("Previous Page", "This is the first page");
+            } else {
+                response.put("Previous Page", url.concat(String.valueOf(pagedTestimonials.getNumber() - 1)));
+            }
+            response.put("Testimonials", testimonialList);
+
+            return response;
+
+        } catch (Exception e) {
+            throw new Exception("Fail to load pages");
+        }
+    }
+
 
 }


### PR DESCRIPTION
COMO usuario
QUIERO visualizar los resultados de Testimonios paginados
PARA aumentar la velocidad de respuesta

Criterios de aceptación:
Cuando se realice la petición para listar, los resultados deberán paginarse de a 10. En la respuesta, se deberán mostrar los resultados y las urls para la página anterior y siguiente (si corresponden). La página actual se obtendrá del parámetro de query ?page

-----

- Se agregó método en el Controller de Testimonios para traer todas las entradas paginadas. 
- Se agregó método en el Service para agregar la lógica y las validaciones correspondientes. 
- Se agregó Query  en el el Repository para traer la información de la base de datos.

![image](https://user-images.githubusercontent.com/91075823/162459037-cdaddd2d-4059-4d0d-815c-3c8b34bcf5f4.png)
![image](https://user-images.githubusercontent.com/91075823/162459456-60858728-90ae-48fb-9827-3577f9b68031.png)
