### PR TITLE
OT169-84 Documentation with Swagger added

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,16 @@
 			<artifactId>jjwt</artifactId>
 			<version>0.9.1</version>
 		</dependency>
-
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger2</artifactId>
+			<version>2.9.2</version>
+		</dependency>
+		<dependency>
+			<groupId>io.springfox</groupId>
+			<artifactId>springfox-swagger-ui</artifactId>
+			<version>2.9.2</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>

--- a/src/main/java/com/alkemy/ong/config/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -31,10 +32,26 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Autowired
     private JwtRequestFilter jwtRequestFilter;
 
+    private static final String[] swaggerWhitelist = {
+            "/configuration/ui",
+            "/swagger-resources",
+            "/swagger-ui.html",
+            "/webjars/**",
+            "/swagger-resources/configuration/ui",
+            "/swagger-ui.html",
+            "/swagger-ui/**",
+            "/api/docs",
+            "/v2/api-docs"
+    };
 
     @Override
     public void configure(AuthenticationManagerBuilder authenticationManagerBuilder) throws Exception {
         authenticationManagerBuilder.userDetailsService(userDetailsCustomService).passwordEncoder(passwordEncoder());
+    }
+
+    @Override
+    public void configure(WebSecurity webSecurity){
+        webSecurity.ignoring().antMatchers(swaggerWhitelist);
     }
 
     @Bean

--- a/src/main/java/com/alkemy/ong/config/SwaggerConfig.java
+++ b/src/main/java/com/alkemy/ong/config/SwaggerConfig.java
@@ -1,0 +1,71 @@
+package com.alkemy.ong.config;
+
+import com.alkemy.ong.dto.CategoryBasicDto;
+import com.alkemy.ong.entity.Role;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.multipart.MultipartFile;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.ApiKey;
+import springfox.documentation.service.AuthorizationScope;
+import springfox.documentation.service.SecurityReference;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.contexts.SecurityContext;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.io.InputStream;
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+
+    @Bean
+    public Docket api(){
+        return new Docket(DocumentationType.SWAGGER_2)
+                .ignoredParameterTypes(CategoryBasicDto.class, MultipartFile.class, InputStream.class, Role.class, Timestamp.class)
+                .securityContexts(Arrays.asList(securityContext()))
+                .securitySchemes(Arrays.asList(apiKey()))
+                .select()
+                .apis(RequestHandlerSelectors.basePackage("com.alkemy.ong.controller"))
+                .paths(PathSelectors.any())
+                .build()
+                .apiInfo(apiDetails());
+    }
+
+
+
+    private ApiInfo apiDetails(){
+        return new ApiInfo(
+                "Somos Más API",
+                "API de la ONG Somos Más",
+                "1.0",
+                "Términos de Servicio",
+                new springfox.documentation.service.Contact("Somos Más","www.somosmasong.com","somosfundacionmas@gmail.com"),
+                "ONG Somos Más API License",
+                "API licence URL",
+                Collections.emptyList());
+    }
+
+    private ApiKey apiKey() {
+        return new ApiKey("JWT", "Authorization", "header");
+    }
+
+    private SecurityContext securityContext() {
+        return SecurityContext.builder().securityReferences(defaultAuth()).build();
+    }
+
+    private List<SecurityReference> defaultAuth() {
+        AuthorizationScope authorizationScope = new AuthorizationScope("global", "accessEverything");
+        AuthorizationScope[] authorizationScopes = new AuthorizationScope[1];
+        authorizationScopes[0] = authorizationScope;
+        return Arrays.asList(new SecurityReference("JWT", authorizationScopes));
+    }
+
+}

--- a/src/main/java/com/alkemy/ong/controller/SwaggerController.java
+++ b/src/main/java/com/alkemy/ong/controller/SwaggerController.java
@@ -1,0 +1,15 @@
+package com.alkemy.ong.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import springfox.documentation.annotations.ApiIgnore;
+
+@Controller
+@ApiIgnore
+public class SwaggerController {
+
+    @RequestMapping("/api/docs")
+    public String getSwaggerDocumentation() {
+        return "redirect:/swagger-ui.html";
+    }
+}

--- a/src/main/java/com/alkemy/ong/dto/ActivityDto.java
+++ b/src/main/java/com/alkemy/ong/dto/ActivityDto.java
@@ -1,5 +1,7 @@
 package com.alkemy.ong.dto;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,15 +13,20 @@ import javax.validation.constraints.NotNull;
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
+@ApiModel(description = "Details about the Activity's DTO")
 public class ActivityDto {
 
+    @ApiModelProperty(notes = "The unique id of the Activity's DTO")
     private String id;
+    @ApiModelProperty(notes = "The Activity's DTO name",required = true,position = 1)
     @NotNull
     @NotBlank(message = "You must provide a name.")
     private String name;
+    @ApiModelProperty(notes = "The Activity's DTO content",required = true,position = 2)
     @NotNull
     @NotBlank(message = "You must provide a content.")
     @Lob
     private String content;
+    @ApiModelProperty(notes = "The Activity's DTO image",position = 3)
     private String image;
 }

--- a/src/main/java/com/alkemy/ong/dto/AuthenticationResponse.java
+++ b/src/main/java/com/alkemy/ong/dto/AuthenticationResponse.java
@@ -1,5 +1,7 @@
 package com.alkemy.ong.dto;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
@@ -7,7 +9,9 @@ import lombok.Setter;
 @Getter
 @Setter
 @AllArgsConstructor
+@ApiModel(description = "Details about jwt for authentication")
 public class AuthenticationResponse {
 
+    @ApiModelProperty(notes = "The Jwt token value for future request")
     private final String jwt;
 }

--- a/src/main/java/com/alkemy/ong/dto/CommentRequestDto.java
+++ b/src/main/java/com/alkemy/ong/dto/CommentRequestDto.java
@@ -1,5 +1,7 @@
 package com.alkemy.ong.dto;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,17 +12,21 @@ import javax.validation.constraints.NotNull;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@ApiModel(description = "Details about the Comment DTO")
 public class CommentRequestDto {
 
     @NotBlank(message = "You must provide a body")
     @NotNull
+    @ApiModelProperty(notes = "The Comment's DTO body",required = true)
     private String body;
 
     @NotBlank(message = "You must provide a post_id")
     @NotNull
+    @ApiModelProperty(notes = "The Comment's DTO post id ",required = true,position = 1)
     private String post_id;
 
     @NotBlank(message = "You must provide a user_id")
     @NotNull
+    @ApiModelProperty(notes = "The Comment's DTO user id",required = true,position = 2)
     private String user_id;
 }

--- a/src/main/java/com/alkemy/ong/dto/CommentResponseDto.java
+++ b/src/main/java/com/alkemy/ong/dto/CommentResponseDto.java
@@ -1,5 +1,7 @@
 package com.alkemy.ong.dto;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,9 +11,11 @@ import javax.persistence.Lob;
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
+@ApiModel(description = "Details about Comment Reponse DTO")
 public class CommentResponseDto {
 
     @Lob
+    @ApiModelProperty(notes = "The Comment's Reponse DTO body")
     private String body;
 
 }

--- a/src/main/java/com/alkemy/ong/dto/NewsDto.java
+++ b/src/main/java/com/alkemy/ong/dto/NewsDto.java
@@ -1,5 +1,7 @@
 package com.alkemy.ong.dto;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,24 +15,28 @@ import java.util.List;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@ApiModel(description = "Details about New's DTO")
 public class NewsDto {
 
-
+    @ApiModelProperty(notes = "The unique id of the New's DTO")
     private String id;
 
     @NotNull
     @NotBlank(message = "You must provide a name")
+    @ApiModelProperty(notes = "The New's DTO name",required = true,position = 1)
     private String name;
 
     @NotNull
     @NotBlank(message = "you must provide a content")
+    @ApiModelProperty(notes = "The New's DTO content",required = true,position = 2)
     private String content;
 
     @NotNull
     @NotBlank
+    @ApiModelProperty(notes = "The New's DTO image",required = true,position = 3)
     private String image;
 
-
+    @ApiModelProperty(notes = "The New's DTO list of categories",required = true,position = 4)
     private List<CategoryBasicDto> categories;
 
 }

--- a/src/main/java/com/alkemy/ong/dto/OrganizationRequestDto.java
+++ b/src/main/java/com/alkemy/ong/dto/OrganizationRequestDto.java
@@ -1,5 +1,7 @@
 package com.alkemy.ong.dto;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,37 +14,48 @@ import javax.validation.constraints.NotNull;
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
+@ApiModel(description = "Details about Organization's DTO")
 public class OrganizationRequestDto {
     @NotNull
     @NotBlank
+    @ApiModelProperty(notes = "The Organization's DTO name",required = true)
     private String name;
     @NotNull
     @NotBlank
     @Email
+    @ApiModelProperty(notes = "The Organization's DTO email",required = true,position = 1)
     private String email;
     @NotNull
     @NotBlank
+    @ApiModelProperty(notes = "The Organization's DTO facebook url",required = true,position = 2)
     private String facebookUrl;
     @NotNull
     @NotBlank
+    @ApiModelProperty(notes = "The Organization's DTO linkedin url",required = true,position = 3)
     private String linkedinUrl;
     @NotNull
     @NotBlank
+    @ApiModelProperty(notes = "The Organization's DTO instagram url",required = true,position = 4)
     private String instagramUrl;
     @NotNull
     @NotBlank
+    @ApiModelProperty(notes = "The Organization's DTO image",required = true,position = 5)
     private String image;
     @NotNull
+    @ApiModelProperty(notes = "The Organization's DTO phone",required = true,position = 6)
     private Long phone;
     @NotNull
     @NotBlank
+    @ApiModelProperty(notes = "The Organization's DTO address",required = true,position = 7)
     private String address;
     @NotNull
     @NotBlank
     @Lob
+    @ApiModelProperty(notes = "The Organization's DTO welcome text",required = true,position = 8)
     private String welcomeText;
     @NotNull
     @NotBlank
     @Lob
+    @ApiModelProperty(notes = "The Organization's DTO about us text",required = true,position = 9)
     private String aboutUsText;
 }

--- a/src/main/java/com/alkemy/ong/dto/OrganizationResponseDto.java
+++ b/src/main/java/com/alkemy/ong/dto/OrganizationResponseDto.java
@@ -1,5 +1,7 @@
 package com.alkemy.ong.dto;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,10 +11,20 @@ import java.util.Map;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@ApiModel(description = "Details about Organization's Response DTO")
 public class OrganizationResponseDto {
+	@ApiModelProperty(notes = "The Organization's Response DTO name")
 	private String name;
-	private String image; 
+
+	@ApiModelProperty(notes = "The Organization's Response DTO image",position = 1)
+	private String image;
+
+	@ApiModelProperty(notes = "The Organization's Response DTO phone",position = 2)
 	private Long phone;
+
+	@ApiModelProperty(notes = "The Organization's Response DTO address",position = 3)
 	private String address;
+
+	@ApiModelProperty(notes = "The Organization's Response DTO contacts",position = 4)
 	private Map<String, String> contact;
 }

--- a/src/main/java/com/alkemy/ong/dto/SlideRequestDto.java
+++ b/src/main/java/com/alkemy/ong/dto/SlideRequestDto.java
@@ -1,8 +1,9 @@
 package com.alkemy.ong.dto;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 
-import javax.persistence.Column;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
@@ -11,19 +12,25 @@ import javax.validation.constraints.NotNull;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@ApiModel(description = "Details about Slide's DTO")
 public class SlideRequestDto {
 
     @NotNull(message = "Image cannot be null")
     @NotBlank
+    @ApiModelProperty(notes = "The Slide's DTO image url",required = true)
     private String imgUrl;
 
     @NotNull(message = "Text cannot be null")
     @NotBlank
+    @ApiModelProperty(notes = "The Slide's DTO text",required = true,position = 1)
     private String text;
 
+    @ApiModelProperty(notes = "The Slide's DTO order",position = 2)
     private Integer order;
+
     @NotNull(message = "Organization cannot be null")
     @NotBlank
+    @ApiModelProperty(notes = "The Slide's DTO organization id",required = true,position = 3)
     private String organizationId;
 
 }

--- a/src/main/java/com/alkemy/ong/dto/SlideResponseDto.java
+++ b/src/main/java/com/alkemy/ong/dto/SlideResponseDto.java
@@ -1,5 +1,7 @@
 package com.alkemy.ong.dto;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 
 @Data
@@ -7,12 +9,17 @@ import lombok.*;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@ApiModel(description = "Details about Slide's Response DTO")
 public class SlideResponseDto {
+    @ApiModelProperty(notes = "The Slide's Response DTO image url")
     private String imgUrl;
 
+    @ApiModelProperty(notes = "The Slide's Response DTO order",position = 1)
     private Integer order;
 
+    @ApiModelProperty(notes = "The Slide's Response DTO text",position = 2)
     private String text;
 
+    @ApiModelProperty(notes = "The Slide's Response DTO organization",position = 3)
     private String org;
 }

--- a/src/main/java/com/alkemy/ong/dto/SlideUpdateDto.java
+++ b/src/main/java/com/alkemy/ong/dto/SlideUpdateDto.java
@@ -1,5 +1,7 @@
 package com.alkemy.ong.dto;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 
 
@@ -8,11 +10,15 @@ import lombok.*;
 @NoArgsConstructor
 @Getter
 @Setter
+@ApiModel(description = "Details about Slide's update DTO")
 public class SlideUpdateDto {
 
+    @ApiModelProperty(notes = "The Slide's update DTO image url")
     private String imgUrl;
 
+    @ApiModelProperty(notes = "The Slide's update DTO text",position = 1)
     private String text;
 
+    @ApiModelProperty(notes = "The Slide's update DTO order",position = 2)
     private Integer order;
 }

--- a/src/main/java/com/alkemy/ong/dto/TestimonialDto.java
+++ b/src/main/java/com/alkemy/ong/dto/TestimonialDto.java
@@ -1,6 +1,8 @@
 package com.alkemy.ong.dto;
 
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,20 +13,25 @@ import javax.validation.constraints.NotNull;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@ApiModel(description = "Details about Testimonial's DTO")
 public class TestimonialDto {
 
+    @ApiModelProperty(notes = "The unique id of the Testimonial")
     private String id;
 
     @NotNull
     @NotBlank
+    @ApiModelProperty(notes = "The Testimonial's DTO name",required = true,position = 1)
     private String name;
 
     @NotNull
     @NotBlank
+    @ApiModelProperty(notes = "The Testimonial's DTO image",required = true,position = 2)
     private String image;
 
     @NotNull
     @NotBlank
+    @ApiModelProperty(notes = "The Testimonial's DTO content",required = true,position = 3)
     private String content;
 
 }

--- a/src/main/java/com/alkemy/ong/dto/UserCredentialsDto.java
+++ b/src/main/java/com/alkemy/ong/dto/UserCredentialsDto.java
@@ -1,5 +1,7 @@
 package com.alkemy.ong.dto;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,13 +12,16 @@ import javax.validation.constraints.NotNull;
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
+@ApiModel(description = "Details about the credentials needed to login in the api")
 public class UserCredentialsDto {
 
     @NotNull
     @NotBlank
+    @ApiModelProperty(notes = "The registered user's email",required = true)
     private String email;
     @NotNull
     @NotBlank
+    @ApiModelProperty(notes = "The registered user's password",required = true,position = 1)
     private String password;
 
 

--- a/src/main/java/com/alkemy/ong/entity/Category.java
+++ b/src/main/java/com/alkemy/ong/entity/Category.java
@@ -1,7 +1,8 @@
 package com.alkemy.ong.entity;
 
 
-import lombok.*;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.SQLDelete;
@@ -25,22 +26,29 @@ import java.time.Instant;
 @NoArgsConstructor
 @SQLDelete(sql = "UPDATE categories SET soft_delete = true WHERE id=?")
 @Where(clause = "soft_delete=false")
+@ApiModel(description = "Details about the Category")
 public class Category {
 
 
     @Id
     @GeneratedValue(generator = "uuid")
     @GenericGenerator(name = "uuid", strategy = "uuid2")
+    @ApiModelProperty(notes = "The unique of the Category")
     private String id;
 
     @NonNull
+    @ApiModelProperty(notes = "The Category's name",required = true,position = 1)
     private String name;
     @Nullable
+    @ApiModelProperty(notes = "The Category's description",position = 2)
     private String description;
     @Nullable
+    @ApiModelProperty(notes = "The Category's image",position = 3)
     private String image;
+    @ApiModelProperty(notes = "The Category's timestamp creation",position = 4)
     private Timestamp timestamp = Timestamp.from(Instant.now());
     @Column(name = "soft_delete")
+    @ApiModelProperty(notes = "The Category's logic delete flag",position = 5)
     private boolean soft_delete = Boolean.FALSE;
 
 }

--- a/src/main/java/com/alkemy/ong/entity/Contact.java
+++ b/src/main/java/com/alkemy/ong/entity/Contact.java
@@ -1,5 +1,7 @@
 package com.alkemy.ong.entity;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.annotations.GenericGenerator;
@@ -21,19 +23,32 @@ import java.time.Instant;
 @Table(name = "contacts")
 @SQLDelete(sql = "UPDATE contacts SET soft_delete = true WHERE id=?")
 @Where(clause = "soft_delete = false")
+@ApiModel(description = "Details about the Contact")
 public class Contact implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Id
     @GeneratedValue(generator = "uuid")
     @GenericGenerator(name = "uuid", strategy = "uuid2")
+    @ApiModelProperty(notes = "The unique id of the Contact")
     private String id;
+
+    @ApiModelProperty(notes = "The Contact's name",position = 1)
     private String name;
+
+    @ApiModelProperty(notes = "The Contact's phone",position = 2)
     private String phone;
+
+    @ApiModelProperty(notes = "The Contact's email",position = 3)
     private String email;
+
+    @ApiModelProperty(notes = "The Contact's message",position = 4)
     private String message;
 
+    @ApiModelProperty(notes = "The Contact's timestamp creation",position = 5)
     private Timestamp timestamp = Timestamp.from(Instant.now());
+
+    @ApiModelProperty(notes = "The Contact's logic delete flag",position = 6)
     private boolean softDelete = Boolean.FALSE;
 
 }

--- a/src/main/java/com/alkemy/ong/entity/Member.java
+++ b/src/main/java/com/alkemy/ong/entity/Member.java
@@ -1,6 +1,8 @@
 package com.alkemy.ong.entity;
 
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -23,29 +25,39 @@ import java.time.Instant;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@ApiModel(description = "Details about the Member")
 public class Member {
 
 	@Id
 	@GeneratedValue(generator = "uuid")
 	@GenericGenerator(name = "uuid", strategy = "uuid2")
+	@ApiModelProperty(notes = "The unique id of the Member")
 	private String id;
 
 	@Column(nullable = false)
+	@ApiModelProperty(notes = "The Member's name",required = true,position = 1)
 	private String name;
 
+	@ApiModelProperty(notes = "The Member's facebook url",position = 2)
 	private String facebookUrl;
 
+	@ApiModelProperty(notes = "The Member's instagram url",position = 3)
 	private String instagramUrl;
 
+	@ApiModelProperty(notes = "The Member's instagram url",position = 4)
 	private String linkedinUrl;
 
 	@Column(nullable = false)
+	@ApiModelProperty(notes = "The Member's image",required = true,position = 5)
 	private String image;
 
+	@ApiModelProperty(notes = "The Member's description",position = 6)
 	private String description;
 
+	@ApiModelProperty(notes = "The Member's timestamp creation",position = 7)
 	private Timestamp timestamp = Timestamp.from(Instant.now());
 
 	@Column(name = "soft_delete")
+	@ApiModelProperty(notes = "The Member's logic delete flag",position = 8)
 	private boolean softDelete = Boolean.FALSE;
 }

--- a/src/main/java/com/alkemy/ong/entity/News.java
+++ b/src/main/java/com/alkemy/ong/entity/News.java
@@ -13,6 +13,8 @@ import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -30,33 +32,41 @@ import org.hibernate.annotations.*;
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
 @SQLDelete(sql = "UPDATE news SET soft_delete = TRUE WHERE id=?")
 @Where(clause = "soft_delete = false")
+@ApiModel(description = "Details about the New")
 public class News {
 
 	@Id
 	@GeneratedValue(generator = "uuid")
 	@GenericGenerator(name = "uuid", strategy = "uuid2")
+	@ApiModelProperty(notes = "The unique id of the New")
 	private String id;
 	
 	@Column(nullable = false)
 	@NotNull(message = "Name cannot be null")
+	@ApiModelProperty(notes = "The New's name",required = true,position = 1)
 	private String name;
 	
 	@Column(nullable = false, columnDefinition="TEXT", length = 65535)
 	@NotNull(message = "Content cannot be null")
+	@ApiModelProperty(notes = "The New's content",required = true,position = 2)
 	private String content;
 	
 	@Column(nullable = false)
 	@NotNull(message = "Image cannot be null")
+	@ApiModelProperty(notes = "The New's image",required = true,position = 3)
 	private String image;
 	
 	@OneToMany
 	@JoinColumn(name="Category_ID")
 	@Cascade(CascadeType.ALL)
+	@ApiModelProperty(notes = "The New's list of categories",required = true,position = 4)
 	private List<Category> categories;
-	
+
+	@ApiModelProperty(notes = "The New's timestamp creation",position = 5)
 	private Timestamp timestamp = Timestamp.from(Instant.now());
 
 	@Column(name = "soft_delete")
+	@ApiModelProperty(notes = "The New's logic delete flag",position = 6)
     private boolean softDelete = false;
 	
 

--- a/src/main/java/com/alkemy/ong/entity/User.java
+++ b/src/main/java/com/alkemy/ong/entity/User.java
@@ -13,29 +13,16 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
-import com.fasterxml.jackson.annotation.JsonIdentityInfo;
-import com.fasterxml.jackson.annotation.ObjectIdGenerators;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import javax.persistence.Entity;
-import javax.persistence.Column;
-import javax.persistence.Table;
-import javax.persistence.Id;
-import javax.persistence.GeneratedValue;
-import javax.persistence.ManyToOne;
-import javax.persistence.JoinColumn;
 import javax.persistence.ForeignKey;
-import javax.persistence.CascadeType;
-import java.sql.Timestamp;
-import java.time.Instant;
-
 
 @Entity
 @Table(name = "users")
@@ -44,36 +31,45 @@ import java.time.Instant;
 @NoArgsConstructor
 @SQLDelete(sql = "UPDATE users SET soft_delete = TRUE WHERE id=?")
 @Where(clause = "soft_delete = false")
-
+@ApiModel(description = "Details about the user")
 public class User {
 	
 	@Id
 	@GeneratedValue(generator = "uuid")
 	@GenericGenerator(name = "uuid", strategy = "uuid2")
+    @ApiModelProperty(notes = "The unique id of the user")
 	private String id;
 	
     @Column(nullable = false)
+    @ApiModelProperty(notes = "The User's firstname",required = true,position = 1)
     private String firstName;
 
     @Column(nullable = false)
+    @ApiModelProperty(notes = "The User's lastname",required = true,position = 2)
     private String lastName;
 
     @Column(nullable = false,unique = true)
+    @ApiModelProperty(notes = "The User's email",required = true,position = 3)
     private String email;
 
     @Column(nullable = false)
+    @ApiModelProperty(notes = "The User's password",required = true,position = 4)
     private String password;
 
+    @ApiModelProperty(notes = "The User's photo",position = 5)
     private String photo;
 
+    @ApiModelProperty(notes = "The User's timestamp creation",position = 6)
     private Timestamp timestamp = Timestamp.from(Instant.now());
 
     @ManyToOne(fetch = FetchType.EAGER ,cascade = {CascadeType.PERSIST,CascadeType.MERGE,CascadeType.REFRESH})
     @JoinColumn(name = "role_id",nullable = false,foreignKey=@ForeignKey(name = "FK_role"))
+    @ApiModelProperty(notes = "The User's id role",required = true,position = 7)
     private Role roleId;
     
 
     @Column(name = "soft_delete")
+    @ApiModelProperty(notes = "The User's logic delete flag",position = 8)
     private boolean soft_delete = Boolean.FALSE;
 
 


### PR DESCRIPTION
Criterios de aceptación: 
COMO desarrollador
QUIERO disponer de una documentación de los endpoints de la API
PARA tener referencias del funcionamiento del sistema

Criterios de aceptación:
Se deberá implementar la librería Swagger para documentar los diferentes endpoints del proyecto. Al ingresar al endpoint /api/docs, se deberá mostrar el layout. Adicionalmente, agregar la posibilidad para implementar los diferentes schemas en base a los Comentarios de métodos de cada controlador.

**RESUMEN**

*SWAGGER CONTROLLER*
->Se creo el endpoint para cuando se especifique la ruta "/api/docs" se redireccione a la ui de swagger

*SWAGGER CONFIG*
->Se agrego la configuración para poder habilitar swagger y configurar los paquetes que queremos que documente. Además, se le agrego la posibilidad de agregar en el header de las peticiones el Jwt para la autorización

*POM*
->Se agregaron las dependencias correspondientes para Swagger

*SECURITY CONFIG*
->Se habilitaron que las rutas pertenecientes a la Ui de Swagger no requiera autenticación (solo el layout de Swagger, después para probar cada endpoint se necesita autenticarse)

*ACTIVITY DTO,AUTHENTICATION RESPONSE DTO,COMMENT REQUEST DTO,COMMENT RESPONSE DTO,NEWS DTO,ORGANIZATION REQUEST DTO,ORGANIZATION RESPONSE DTO,SLIDE REQUEST DTO,SLIDE RESPONSE DTO,SLIDE UPDATE DTO,TESTIMONIAL DTO,USER CREADENTIALS DTO,CATEGORY,CONTACT,MEMBER,NEWS,USER
->Se agrego descripciones a los schemas/modelos que swagger reconoce para los endpoints documentados
->Se quitaron algunos imports que no se utilizaban