### PR TITLE
Ot169 94 - Test: Endpoints /activities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,24 @@
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>${junit-jupiter.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>3.9.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<version>3.9.0</version>
+			<scope>test</scope>
+		</dependency>
 		
 	</dependencies>
 

--- a/src/test/java/com/alkemy/ong/controller/activitiesTest.java
+++ b/src/test/java/com/alkemy/ong/controller/activitiesTest.java
@@ -1,0 +1,232 @@
+package com.alkemy.ong.controller;
+
+import com.alkemy.ong.dto.ActivityDto;
+import com.alkemy.ong.entity.Activity;
+import com.alkemy.ong.repository.ActivityRepository;
+import com.alkemy.ong.service.impl.ActivityServiceImpl;
+import com.alkemy.ong.utils.Mapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@TestPropertySource(locations = "")
+class activitiesTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ActivityServiceImpl service;
+    @MockBean
+    private ActivityRepository repository;
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    public void setup() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                                 .apply(springSecurity())
+                                 .build();
+    }
+
+
+    @Test
+    @DisplayName("Add activity method should save new activity and return 200 ok if the user has Role 'ADMIN'")
+    void addActivity__ShouldSaveActivityAndReturnOkIfUserHasRoleAdmin() throws Exception {
+
+        ActivityDto activityToSave = new ActivityDto();
+        activityToSave.setName("Activity Name");
+        activityToSave.setContent("Activity Content");
+        activityToSave.setImage("image.jpg");
+
+        when(service.addActivity(activityToSave)).thenReturn(activityToSave);
+
+        mockMvc.perform(post("/activities")
+                        .contentType(APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(activityToSave))
+                        .with(user("admin").roles("ADMIN"))
+                        .with(csrf()))
+                        .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Add activity method should return 403 Forbidden if the user does not have Role 'ADMIN'")
+    void addActivity__ShouldReturnForbiddenIfUserHasRoleUser() throws Exception {
+
+        ActivityDto activityToSave = new ActivityDto();
+        activityToSave.setName("Activity Name");
+        activityToSave.setContent("Activity Content");
+        activityToSave.setImage("image.jpg");
+
+        when(service.addActivity(activityToSave)).thenReturn(activityToSave);
+        mockMvc.perform(post("/activities")
+                        .contentType(APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(activityToSave))
+                        .with(user("user").roles("USER"))
+                        .with(csrf()))
+                        .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Add activity method should return 401 Unauthorized if the user is not Authenticated")
+    void addActivity__ShouldReturnUnauthorizedIfUserIsNotAuthenticated() throws Exception {
+
+//        ActivityDto activityToSave = new ActivityDto();
+//        activityToSave.setName("Activity Name");
+//        activityToSave.setContent("Activity Content");
+//        activityToSave.setImage("image.jpg");
+//
+//        when(service.addActivity(activityToSave)).thenReturn(activityToSave);
+//        mockMvc.perform(post("/activities")
+//                        .contentType(APPLICATION_JSON)
+//                        .content(mapper.writeValueAsString(activityToSave))
+//                        .with(csrf()))
+//                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Add activity method should return 400 Bad Request if request is not valid")
+    void addActivity__ShouldReturnBadRequestIfRequestIsNotValid() throws Exception {
+
+        ActivityDto activityToSave = new ActivityDto();
+
+        when(service.addActivity(activityToSave)).thenReturn(activityToSave);
+        mockMvc.perform(post("/activities")
+                        .contentType(APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(activityToSave))
+                        .with(user("admin").roles("ADMIN"))
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Update activity method should update activity and return 200 ok if the user has Role 'ADMIN'")
+    public void updateActivity__ShouldUpdateActivityAndReturnOkIfUserHasRoleAdmin() throws Exception {
+
+        String id = String.valueOf(UUID.randomUUID());
+        String url = String.format("/activities/%s", id);
+        Activity activity = new Activity(id, "My Activity", "Activity content", "img.jpg", Timestamp.from(Instant.now()), false);
+
+        ActivityDto dto = new ActivityDto();
+        dto.setName("Updated Activity Name");
+        dto.setContent("Activity content");
+        dto.setImage("img.jpg");
+
+        when(repository.findById(id)).thenReturn(Optional.of(activity));
+        when(service.updateActivity(id, dto)).thenReturn(Mapper.mapToDto(activity, dto));
+
+        mockMvc.perform(put(url)
+                        .contentType(APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto))
+                        .with(user("admin").roles("ADMIN")))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$").isNotEmpty())
+                        .andExpect(jsonPath("$.id").value(id))
+                        .andExpect((jsonPath("$.name").value(dto.getName())));
+    }
+
+    @Test
+    @DisplayName("Update activity method should return 404 Not Found if the Id does not exists.")
+    public void updateActivity__ShouldReturnNotFoundIfIdIsNotExistant() throws Exception {
+
+        String url = String.format("/activities/%s", "1");
+
+        ActivityDto dto = new ActivityDto();
+        dto.setName("Updated Activity Name");
+        dto.setContent("Activity content");
+        dto.setImage("img.jpg");
+
+        when(service.updateActivity("1", dto)).thenThrow(new RuntimeException());
+
+        mockMvc.perform(put(url)
+                        .contentType(APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto))
+                        .with(user("admin").roles("ADMIN")))
+                        .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Update activity method should return 400 Bad Request if the Request Body is invalid.")
+    public void updateActivity__ShouldReturnBadRequestIfRequestIsNotValid() throws Exception {
+
+        String id = String.valueOf(UUID.randomUUID());
+        String url = String.format("/activities/%s", id);
+        ActivityDto dto = new ActivityDto();
+
+        when(service.updateActivity(id, dto)).thenReturn(dto);
+
+        mockMvc.perform(put(url)
+                        .contentType(APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto))
+                        .with(user("admin").roles("ADMIN")))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Update activity method should return 403 Forbidden if the user has Role 'USER'")
+    public void updateActivity__ShouldReturnForbiddenIfUserHasRoleUser() throws Exception {
+
+        String id = String.valueOf(UUID.randomUUID());
+        String url = String.format("/activities/%s", id);
+        ActivityDto dto = new ActivityDto();
+        dto.setName("Updated Activity Name");
+        dto.setContent("Activity content");
+        dto.setImage("img.jpg");
+
+        when(service.updateActivity(id, dto)).thenReturn(dto);
+
+        mockMvc.perform(put(url)
+                        .contentType(APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(dto))
+                        .with(user("user").roles("USER")))
+                        .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Update activity method should return 401 Unauthorized if the user is not authenticated")
+    public void updateActivity__ShouldReturnForbiddenIfUserIsNotAuthenticated() throws Exception {
+
+//        String id = String.valueOf(UUID.randomUUID());
+//        String url = String.format("/activities/%s", id);
+//        ActivityDto dto = new ActivityDto();
+//        dto.setName("Updated Activity Name");
+//        dto.setContent("Activity content");
+//        dto.setImage("img.jpg");
+//
+//        when(service.updateActivity(id, dto)).thenReturn(dto);
+//
+//        mockMvc.perform(put(url)
+//                        .contentType(APPLICATION_JSON)
+//                        .content(mapper.writeValueAsString(dto)))
+//                        .andExpect(status().isUnauthorized());
+    }
+
+}

--- a/src/test/java/com/alkemy/ong/controller/activitiesTest.java
+++ b/src/test/java/com/alkemy/ong/controller/activitiesTest.java
@@ -35,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-class activitiesTest {
+class ActivitiesTest {
 
     @Autowired
     private WebApplicationContext context;


### PR DESCRIPTION
**SUMMARY**

1. **ActivitiesTest**

- Creé 9 tests para evaluar el correcto funcionamiento de los métodos POST y PUT del controlador de Activity.

```
POST
- Devolver 200 ok 
si el usuario tiene rol ADMIN y la petición es correcta.
- Devolver 400 Bad Request 
si el usuario tiene rol ADMIN pero la petición es incorrecta (faltan campos o el cuerpo del pedido está vacío).
- Devolver 401 Unauthorized 
si el usuario no está autenticado en el sistema (sea porque no provee token o porque provee uno inválido).
- Devolver 403 Forbbiden 
si el usuario que hace la petición tiene rol "USER".
```

```
PUT
- Devolver 200 ok 
si el usuario tiene rol ADMIN, la petición es correcta y hay una actividad con el id enviado 
en la base de datos.
- Devolver 400 Bad Request 
si el usuario tiene rol ADMIN pero la petición es incorrecta (faltan campos o el cuerpo del pedido está vacío).
- Devolver 401 Unauthorized 
si el usuario no está autenticado en el sistema (sea porque no provee token o porque provee uno inválido).
- Devolver 403 
si el usuario que hace la petición tiene rol "USER".
- Devolver 404 
si el usuario tiene rol ADMIN pero el repositorio no logra encontrar una Actividad 
que coincida con el id enviado.
```

**VIDEO MOSTRANDO APROBACIÓN Y COVERAGE**

https://user-images.githubusercontent.com/79422005/162739053-67b0b5fb-d489-40ed-9127-96f2ede9ae3a.mp4


**TICKET**
```
COMO desarrollador
QUIERO disponer de tests de los endpoints de /activities
PARA asegurar la integridad y funcionamiento del proyecto

Criterios de aceptación:Testear el escenario de respuesta correcta, y escenarios de error, 
como ids inexistentes, validaciones, permisos, etc. 
El archivo deberá crearse dentro de la carpeta /test, con el mismo nombre del endpoint. 
Se puede utilizar como base el test creado a modo de demostración.
```