### PR TITLE
Agregar documentación a Testimonios OT169-88

### DIFF
--- a/src/main/java/com/alkemy/ong/controller/TestimonialController.java
+++ b/src/main/java/com/alkemy/ong/controller/TestimonialController.java
@@ -4,6 +4,7 @@ package com.alkemy.ong.controller;
 import com.alkemy.ong.dto.TestimonialDto;
 import com.alkemy.ong.repository.TestimonialRepository;
 import com.alkemy.ong.service.TestimonialService;
+import io.swagger.annotations.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +18,7 @@ import java.util.Map;
 
 @RestController
 @RequestMapping("/testimonials")
+@Api(tags = "Testimonials endpoints")
 public class TestimonialController {
 
 
@@ -24,6 +26,17 @@ public class TestimonialController {
     private TestimonialService testimonialService;
 
 
+    //**POST**//
+    @ApiOperation(value = "Add a new testimonial and return it")
+    @ApiResponses(value = { @ApiResponse(code = 201 , message= "Create Testimonial"),
+            @ApiResponse(code = 403, message = "Forbidden/Accessing with invalid role"),
+            @ApiResponse(code = 400 , message = "Bad request/Invalid field")
+    })
+    @ApiImplicitParam(name = "Authorization", value = "Access Token",
+            required = true,
+            allowEmptyValue = false,
+            paramType = "header",
+            dataTypeClass = String.class)
     @PostMapping
     public ResponseEntity<TestimonialDto> save(@Valid @RequestBody TestimonialDto testimonialDto){
         TestimonialDto savedTestimonials = testimonialService.save(testimonialDto);
@@ -31,12 +44,51 @@ public class TestimonialController {
     }
 
 
+    //**DELETE**//
+    @ApiOperation(value = "Delete a testimonial by id")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Delete Testimonial by id"),
+            @ApiResponse(code = 404, message = "Testimonial not found"),
+            @ApiResponse(code = 403, message = "Forbidden/Accessing with invalid role" )})
+    @ApiImplicitParams(value = {
+            @ApiImplicitParam(name = "id",
+                    value = "Id of the testimonial we want to delete",
+                    required = true,
+                    allowEmptyValue = false,
+                    paramType = "path",
+                    dataTypeClass = String.class),
+             @ApiImplicitParam(name = "Authorization", value = "Access Token",
+                    required = true,
+                    allowEmptyValue = false,
+                    paramType = "header",
+                    dataTypeClass = String.class)})
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable String id){
         testimonialService.delete(id);
         return  ResponseEntity.status(HttpStatus.OK).build();
     }
 
+
+
+    //**PUT**/
+    @ApiOperation(value = "Update a testimonial by id")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Update testimonial"),
+            @ApiResponse(code = 404, message = "Testimonial not found"),
+            @ApiResponse(code = 403, message = "Forbidden/Accessing with invalid role" ),
+            @ApiResponse(code = 400 , message = "Bad request/Invalid field")
+
+    })
+    @ApiImplicitParams(value = {
+            @ApiImplicitParam(name = "id",
+                    value = "Id of the testimonial we want to modify",
+                    required = true,
+                    allowEmptyValue = false,
+                    paramType = "path",
+                    dataTypeClass = String.class),
+            @ApiImplicitParam(name = "Authorization", value = "Access Token",
+                    required = true,
+                    allowEmptyValue = false,
+                    paramType = "header",
+                    dataTypeClass = String.class)})
     @PutMapping("/{id}")
     public ResponseEntity<TestimonialDto> updateTestimonials(@Valid @RequestBody TestimonialDto testimonialDto, @PathVariable String id) throws ResponseStatusException{
         try {
@@ -47,6 +99,17 @@ public class TestimonialController {
         }
     }
 
+
+    //**PAGINATION**//
+    @ApiOperation(value = "Get a paginated list of testimonials")
+    @ApiResponses(value = { @ApiResponse(code = 200, message = "Return a paginated list of testimonials"),
+            @ApiResponse(code = 403, message = "Forbidden/Accessing with invalid role" )
+    })
+    @ApiImplicitParam(name = "Authorization", value = "Access Token",
+            required = true,
+            allowEmptyValue = false,
+            paramType = "header",
+            dataTypeClass = String.class)
     @GetMapping("/pages")
     public ResponseEntity<Map<String, Object>> getAllPage(@RequestParam(defaultValue = "0") int page) {
         Map<String, Object> testimonial = new HashMap<>();

--- a/src/main/java/com/alkemy/ong/controller/TestimonialController.java
+++ b/src/main/java/com/alkemy/ong/controller/TestimonialController.java
@@ -31,6 +31,7 @@ public class TestimonialController {
     @ApiResponses(value = { @ApiResponse(code = 201 , message= "Create Testimonial"),
             @ApiResponse(code = 403, message = "Forbidden/Accessing with invalid role"),
             @ApiResponse(code = 400 , message = "Bad request/Invalid field")
+
     })
     @ApiImplicitParam(name = "Authorization", value = "Access Token",
             required = true,
@@ -102,9 +103,7 @@ public class TestimonialController {
 
     //**PAGINATION**//
     @ApiOperation(value = "Get a paginated list of testimonials")
-    @ApiResponses(value = { @ApiResponse(code = 200, message = "Return a paginated list of testimonials"),
-            @ApiResponse(code = 403, message = "Forbidden/Accessing with invalid role" )
-    })
+    @ApiResponse(code = 200, message = "Return a paginated list of testimonials")
     @ApiImplicitParam(name = "Authorization", value = "Access Token",
             required = true,
             allowEmptyValue = false,


### PR DESCRIPTION
COMO desarrollador
QUIERO disponer de una documentación de los endpoints de Testimonios
PARA tener referencias de su funcionamiento

Criterios de aceptación:
Se deberán documentar los diferentes endpoints especificando el modelo de datos, 
campos obligatorios, formato de la petición y ejemplo de la misma.