### PR TITLE
Test: Endpoints /news OT169-93

### DIFF
--- a/src/main/java/com/alkemy/ong/controller/NewsController.java
+++ b/src/main/java/com/alkemy/ong/controller/NewsController.java
@@ -38,23 +38,18 @@ public class NewsController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<NewsDto> updateNews(@PathVariable String id,@Valid @RequestBody NewsDto newsDto) throws ResponseStatusException {
-        try{
-            newsService.updateNews( id, newsDto);
-            return ResponseEntity.status(HttpStatus.OK).body(newsDto);
-          }
-            catch (Exception e){
-             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-            }
+    public ResponseEntity<NewsDto> updateNews(@PathVariable String id,@Valid @RequestBody NewsDto newsDto) {
+        newsService.updateNews( id, newsDto);
+        return ResponseEntity.status(HttpStatus.OK).body(newsDto);
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void>delete(@PathVariable String id) {
-       newsService.delete(id);
-       return ResponseEntity.status(HttpStatus.OK).build();
+        newsService.delete(id);
+        return ResponseEntity.status(HttpStatus.OK).build();
     }
 
-    @GetMapping("/pages")
+    @GetMapping
     public ResponseEntity<Map<String, Object>> getAllPage(@RequestParam(defaultValue = "0") Integer page){
         Map<String, Object> news = new HashMap<>();
         try {
@@ -65,15 +60,5 @@ public class NewsController {
         }
     }
 
-
-
-
-
-
-
-
 }
-
-
-
 

--- a/src/main/java/com/alkemy/ong/service/impl/NewsServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/NewsServiceImpl.java
@@ -93,7 +93,7 @@ public class NewsServiceImpl implements NewsService {
         try {
             List<List<LinkedHashMap>> newsList = new ArrayList<List<LinkedHashMap>>();
             Pageable paging = PageRequest.of(page,size);
-            String url = "/news/pages?page=";
+            String url = "/news?page=";
 
             Page<List<LinkedHashMap>> pagedNews;
             pagedNews = newsRepository.findPage(paging);

--- a/src/test/java/com/alkemy/ong/controller/NewsControllerTest.java
+++ b/src/test/java/com/alkemy/ong/controller/NewsControllerTest.java
@@ -2,44 +2,37 @@ package com.alkemy.ong.controller;
 
 import com.alkemy.ong.dto.CategoryBasicDto;
 import com.alkemy.ong.dto.NewsDto;
-import com.alkemy.ong.entity.Category;
+
 import com.alkemy.ong.entity.News;
 import com.alkemy.ong.repository.NewsRepository;
 import com.alkemy.ong.service.NewsService;
-import com.alkemy.ong.service.impl.NewsServiceImpl;
-import com.alkemy.ong.utils.Mapper;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.amazonaws.services.simplesystemsmanagement.model.ParameterNotFoundException;
+import com.amazonaws.services.simpleworkflow.flow.annotations.Workflow;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.hibernate.validator.constraints.URL;
+
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mock;
+
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
-import org.springframework.test.web.servlet.ResultMatcher;
+
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.server.ResponseStatusException;
 
 
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-
-import static java.util.Arrays.asList;
-import static org.hibernate.validator.internal.util.Contracts.assertTrue;
+import java.util.*;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -56,7 +49,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 class NewsControllerTest{
 
-    private final String URL = "/news";
 
     @Autowired
     private WebApplicationContext context;
@@ -76,6 +68,9 @@ class NewsControllerTest{
     private News news;
     private NewsDto newsDto;
     private List<CategoryBasicDto>categories = new ArrayList<CategoryBasicDto>();
+    private final static int PAGE = 0;
+    private final static int SIZE = 2;
+    private final String URL = "/news";
 
 
 
@@ -105,6 +100,7 @@ class NewsControllerTest{
 
     @Test
     @WithMockUser(roles = "ADMIN")
+    @DisplayName("Save News Success (Code 201 Created) with role ADMIN")
     void createNews_Ok() throws Exception {
         when(newsService.save(newsDto)).thenReturn(newsDto);
         mockMvc.perform(post(URL)
@@ -117,7 +113,8 @@ class NewsControllerTest{
     }
 
     @Test
-    @WithMockUser(username = "ADMIN" , roles = {"ADMIN"})
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("Fail Saving News due to incomplete fields (Error 400 Bad Request)")
     void createNews_BadRequest() throws Exception{
 
         newsDto.setName(null);
@@ -129,7 +126,8 @@ class NewsControllerTest{
 
     }
     @Test
-    @WithMockUser(username = "ADMIN", roles = {"ADMIN"})
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("Fail Saving News due to wrong role (Error 403 Forbidden)")
     void createNews_FailBecauseUserIsNotAdmin() throws Exception {
         when(newsService.save(newsDto)).thenReturn(newsDto);
         mockMvc.perform(post(URL)
@@ -144,35 +142,59 @@ class NewsControllerTest{
     //GET//
 
     @Test
-    @WithMockUser(username = "ADMIN" , roles = {"ADMIN"})
+    @WithMockUser(roles = "ADMIN")
     void getNewsById_Ok() throws Exception {
         String id = "123abc";
-        when(newsService.getNewsById("123abc")).thenReturn(newsDto);
+        when(newsService.getNewsById(id)).thenReturn(newsDto);
 
-        mockMvc.perform(get("/news/{id}", "123abc")
+        mockMvc.perform(get("/news/{id}", id)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
     }
 
     @Test
-    @WithMockUser(username = "USER" , roles = {"USER"})
-    void getAllPage_Ok() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get("/news/pages".concat("?page=")))
-                .andExpect(MockMvcResultMatchers.status().isOk());
+    @WithMockUser(roles = "ADMIN")
+    void getNewsById_NotFound() throws Exception{
+        String idNotFound = "456def";
+
+        when(newsService.getNewsById(idNotFound)).thenThrow((new ParameterNotFoundException("")));
+        mockMvc.perform(get(URL+idNotFound)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newsDto)))
+                .andExpect(status().isNotFound());
     }
 
     @Test
-    @WithMockUser(username = "ADMIN", roles = {"ADMIN"})
+    @WithMockUser(roles = "ADMIN")
+    void getAllPage_Ok() throws Exception {
+
+        Map<String, Object> response = new LinkedHashMap<>();
+        when(newsService.getAllPages(0)).thenReturn(response);
+
+        mockMvc.perform(MockMvcRequestBuilders.get(URL+"/pages?page")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(response)))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
     void getAllPage_Forbidden()throws Exception{
-        mockMvc.perform(MockMvcRequestBuilders.get("/news/pages".concat("?page=")))
-                .andExpect(MockMvcResultMatchers.status().isForbidden());
+        Map<String, Object> response = new LinkedHashMap<>();
+        when(newsService.getAllPages(0)).thenThrow(new Exception("Fail to load pages"));
+
+        mockMvc.perform(MockMvcRequestBuilders.get(URL+"/pages?page")
+                        .contentType(APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().is5xxServerError());
     }
 
     //PUT//
 
     @Test
-    @WithMockUser(username = "ADMIN", roles = {"ADMIN"})
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("Update News: Success (Code 200 OK)")
     void updateNews_Ok() throws Exception {
         String id = "123abc";
 
@@ -189,10 +211,11 @@ class NewsControllerTest{
     }
 
     @Test
-    @WithMockUser(username = "ADMIN", roles = {"ADMIN"})
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("Fail Updating News due to non-existent ID (Error 404 Not Found)")
     void updateNews_NotFoundById() throws Exception{
         String idNotFound = "456def";
-        when(newsService.updateNews(idNotFound, newsDto)).thenThrow((new RuntimeException()));
+        when(newsService.updateNews(idNotFound, newsDto)).thenThrow((new ParameterNotFoundException("")));
         mockMvc.perform(put(URL+idNotFound)
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(newsDto)))
@@ -201,7 +224,8 @@ class NewsControllerTest{
     }
 
     @Test
-    @WithMockUser(username = "ADMIN", roles = {"ADMIN"})
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("Fail Updating News due to incorrect role (Error 403 Forbidden)")
     void updateNews_FailBecauseUserIsNotAdmin() throws Exception{
         when(newsService.updateNews("123abc", newsDto)).thenReturn(newsDto);
         mockMvc.perform(put(URL + "/123abc")
@@ -214,10 +238,13 @@ class NewsControllerTest{
     }
 
     @Test
-    @WithMockUser(username = "ADMIN", roles = {"ADMIN"})
+    @WithMockUser(roles= "ADMIN")
+    @DisplayName("Fail Updating News due to incomplete fields (Error 400 Bad Request)")
     void updateNews_BadRequest() throws Exception{
         newsDto.setName(null);
         newsDto.setImage(null);
+        newsDto.setContent(null);
+
         mockMvc.perform(put(URL + "/123abc")
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(newsDto))
@@ -232,7 +259,8 @@ class NewsControllerTest{
     //DELETE//
 
     @Test
-    @WithMockUser(username = "ADMIN" , roles = {"ADMIN"})
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("Delete News: Success (Code 200 OK)")
     void delete_Ok() throws Exception{
         newsService.delete("123abc");
 
@@ -244,7 +272,8 @@ class NewsControllerTest{
     }
 
     @Test
-    @WithMockUser(username = "ADMIN", roles = {"ADMIN"})
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("Fail Deleting News due to non-existent ID (Error 404 Not Found)")
     void delete_NotFound() throws Exception{
         String idNotFound = "456def";
         newsService.delete("456def");
@@ -255,7 +284,8 @@ class NewsControllerTest{
     }
 
     @Test
-    @WithMockUser(username = "ADMIN", roles = {"ADMIN"})
+    @WithMockUser(roles = "ADMIN")
+    @DisplayName("Fail Deleting News due to incorrect user role (Error 403 Forbidden)")
     void delete_FailBecauseUserIsNotAdmin() throws Exception {
         newsService.delete("123abc");
 

--- a/src/test/java/com/alkemy/ong/controller/NewsControllerTest.java
+++ b/src/test/java/com/alkemy/ong/controller/NewsControllerTest.java
@@ -1,0 +1,143 @@
+package com.alkemy.ong.controller;
+
+import com.alkemy.ong.entity.News;
+import com.alkemy.ong.repository.NewsRepository;
+import com.alkemy.ong.service.impl.NewsServiceImpl;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hibernate.validator.constraints.URL;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class NewsControllerTest{
+
+        @Autowired
+        protected MockMvc mockMvc;
+
+        @Autowired
+        private NewsRepository newsRepository;
+
+        @Mock
+        private NewsServiceImpl newsServiceImpl;
+
+         @Autowired
+         ObjectMapper objectMapper;
+
+    @Autowired
+    private WebApplicationContext context;
+
+
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+
+
+    }
+
+
+    @Test
+    @WithMockUser(username = "ADMIN" , roles = {"ADMIN"})
+    void createNews_Ok() throws Exception {
+
+      News news = new News();
+        news.setId("01");
+        news.setImage("soy una imagen");
+        news.setName("nombre");
+        news.setContent("content");
+        //VER QUE HAGO CON EL CATEGORIES
+        news = newsRepository.save(news);
+
+         //   when(newsRepository.save(news)).thenReturn(news);
+
+       mockMvc.perform(post("/news")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+        //RESULTADO:  OK
+    }
+
+    @Test
+    @WithMockUser(username = "ADMIN" , roles = {"ADMIN"})
+    void createNews_BadRequest() throws Exception{
+        News news = new News();
+        news.setId("01"); //SETEO EL ID???????
+        news.setImage(null);
+        news.setName(null);
+        news.setContent(null);
+        //news = newsRepository.save(news);
+
+
+        mockMvc.perform(post("/news")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(news)))
+                .andExpect(status().isBadRequest());
+        // RESULTADO: ME DICE QUE ESPERA UN 400 PERO DEVUELVE UN 403.
+    }
+
+
+
+    @Test
+    void getNewsById() {
+
+    }
+
+    @Test
+    void updateNews() {
+    }
+
+    @Test
+    @WithMockUser(username = "ADMIN" , roles = {"ADMIN"})
+    void delete_Ok() throws Exception{
+        News news = new News();
+        news.setId("123abc");
+
+         //when(newsRepository.findById(news.getId())).thenReturn(Optional.of(news));
+
+        mockMvc.perform(MockMvcRequestBuilders.delete("/news/{id}",20))
+               .andExpect(status().isOk());
+
+            /*RESULTADO: espera un 200 devuelve un 404*/
+
+             /*News news = new News();
+              newsRepository.delete(news);
+                 mockMvc.perform(delete(URL+"/" + news.getId()))
+                         .andExpect(status().isOk());*/
+    }
+
+    @Test
+    @WithMockUser(username = "ADMIN", roles = {"ADMIN"})
+    void delete_NotFound() throws Exception{
+        News news = new News();
+        news.setId("123abc");
+
+        mockMvc.perform(MockMvcRequestBuilders.delete("/news/{id}", news.getId()))
+                .andExpect(status().isNotFound());
+
+            //resultado: ok ???????????????
+    }
+
+}

--- a/src/test/java/com/alkemy/ong/controller/NewsControllerTest.java
+++ b/src/test/java/com/alkemy/ong/controller/NewsControllerTest.java
@@ -1,30 +1,53 @@
 package com.alkemy.ong.controller;
 
+import com.alkemy.ong.dto.CategoryBasicDto;
+import com.alkemy.ong.dto.NewsDto;
+import com.alkemy.ong.entity.Category;
 import com.alkemy.ong.entity.News;
 import com.alkemy.ong.repository.NewsRepository;
+import com.alkemy.ong.service.NewsService;
 import com.alkemy.ong.service.impl.NewsServiceImpl;
+import com.alkemy.ong.utils.Mapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hibernate.validator.constraints.URL;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
+import org.springframework.test.web.servlet.ResultMatcher;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+
+import static java.util.Arrays.asList;
+import static org.hibernate.validator.internal.util.Contracts.assertTrue;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
 
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -33,20 +56,26 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 class NewsControllerTest{
 
-        @Autowired
-        protected MockMvc mockMvc;
-
-        @Autowired
-        private NewsRepository newsRepository;
-
-        @Mock
-        private NewsServiceImpl newsServiceImpl;
-
-         @Autowired
-         ObjectMapper objectMapper;
+    private final String URL = "/news";
 
     @Autowired
     private WebApplicationContext context;
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    private NewsRepository newsRepository;
+
+    @MockBean
+    private NewsService newsService;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    private News news;
+    private NewsDto newsDto;
+    private List<CategoryBasicDto>categories = new ArrayList<CategoryBasicDto>();
 
 
 
@@ -56,88 +85,186 @@ class NewsControllerTest{
                 .apply(springSecurity())
                 .build();
 
+        news = new News();
+        news.setId("123abc");
+        news.setName("name");
+        news.setImage("image");
+        news.setContent("content");
+        news.setSoftDelete(false);
+
+
+        newsDto = new NewsDto();
+        newsDto.setName("name");
+        newsDto.setImage("image");
+        newsDto.setContent("content");
+        categories.add(new CategoryBasicDto("name"));
+        newsDto.setCategories(categories);
 
     }
-
+    //POST//
 
     @Test
-    @WithMockUser(username = "ADMIN" , roles = {"ADMIN"})
+    @WithMockUser(roles = "ADMIN")
     void createNews_Ok() throws Exception {
+        when(newsService.save(newsDto)).thenReturn(newsDto);
+        mockMvc.perform(post(URL)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newsDto))
+                        .with(user("admin").roles("ADMIN"))
+                        .with(csrf()))
+                .andExpect(status().isCreated());
 
-      News news = new News();
-        news.setId("01");
-        news.setImage("soy una imagen");
-        news.setName("nombre");
-        news.setContent("content");
-        //VER QUE HAGO CON EL CATEGORIES
-        news = newsRepository.save(news);
-
-         //   when(newsRepository.save(news)).thenReturn(news);
-
-       mockMvc.perform(post("/news")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isForbidden());
-        //RESULTADO:  OK
     }
 
     @Test
     @WithMockUser(username = "ADMIN" , roles = {"ADMIN"})
     void createNews_BadRequest() throws Exception{
-        News news = new News();
-        news.setId("01"); //SETEO EL ID???????
-        news.setImage(null);
-        news.setName(null);
-        news.setContent(null);
-        //news = newsRepository.save(news);
 
-
-        mockMvc.perform(post("/news")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(news)))
+        newsDto.setName(null);
+        mockMvc.perform(post(URL)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newsDto)))
                 .andExpect(status().isBadRequest());
-        // RESULTADO: ME DICE QUE ESPERA UN 400 PERO DEVUELVE UN 403.
+
+
+    }
+    @Test
+    @WithMockUser(username = "ADMIN", roles = {"ADMIN"})
+    void createNews_FailBecauseUserIsNotAdmin() throws Exception {
+        when(newsService.save(newsDto)).thenReturn(newsDto);
+        mockMvc.perform(post(URL)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newsDto))
+                        .with(user("user").roles("USER"))
+                        .with(csrf()))
+                .andExpect(status().isForbidden());
+
     }
 
-
+    //GET//
 
     @Test
-    void getNewsById() {
+    @WithMockUser(username = "ADMIN" , roles = {"ADMIN"})
+    void getNewsById_Ok() throws Exception {
+        String id = "123abc";
+        when(newsService.getNewsById("123abc")).thenReturn(newsDto);
+
+        mockMvc.perform(get("/news/{id}", "123abc")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
 
     }
 
     @Test
-    void updateNews() {
+    @WithMockUser(username = "USER" , roles = {"USER"})
+    void getAllPage_Ok() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/news/pages".concat("?page=")))
+                .andExpect(MockMvcResultMatchers.status().isOk());
     }
+
+    @Test
+    @WithMockUser(username = "ADMIN", roles = {"ADMIN"})
+    void getAllPage_Forbidden()throws Exception{
+        mockMvc.perform(MockMvcRequestBuilders.get("/news/pages".concat("?page=")))
+                .andExpect(MockMvcResultMatchers.status().isForbidden());
+    }
+
+    //PUT//
+
+    @Test
+    @WithMockUser(username = "ADMIN", roles = {"ADMIN"})
+    void updateNews_Ok() throws Exception {
+        String id = "123abc";
+
+        when(newsService.updateNews("123abc", newsDto)).thenReturn(newsDto);
+        mockMvc.perform(put(URL+"/123abc")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newsDto))
+                        .with(user("admin").roles("ADMIN"))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value("name"))
+                .andExpect(jsonPath("$.image").value("image"))
+                .andExpect(jsonPath("$.content").value("content"));
+    }
+
+    @Test
+    @WithMockUser(username = "ADMIN", roles = {"ADMIN"})
+    void updateNews_NotFoundById() throws Exception{
+        String idNotFound = "456def";
+        when(newsService.updateNews(idNotFound, newsDto)).thenThrow((new RuntimeException()));
+        mockMvc.perform(put(URL+idNotFound)
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newsDto)))
+                .andExpect(status().isNotFound());
+
+    }
+
+    @Test
+    @WithMockUser(username = "ADMIN", roles = {"ADMIN"})
+    void updateNews_FailBecauseUserIsNotAdmin() throws Exception{
+        when(newsService.updateNews("123abc", newsDto)).thenReturn(newsDto);
+        mockMvc.perform(put(URL + "/123abc")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newsDto))
+                        .with(user("user").roles("USER"))
+                        .with(csrf()))
+                .andExpect(status().isForbidden());
+
+    }
+
+    @Test
+    @WithMockUser(username = "ADMIN", roles = {"ADMIN"})
+    void updateNews_BadRequest() throws Exception{
+        newsDto.setName(null);
+        newsDto.setImage(null);
+        mockMvc.perform(put(URL + "/123abc")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(newsDto))
+                        .with(user("admin").roles("ADMIN"))
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+
+    }
+
+
+
+    //DELETE//
 
     @Test
     @WithMockUser(username = "ADMIN" , roles = {"ADMIN"})
     void delete_Ok() throws Exception{
-        News news = new News();
-        news.setId("123abc");
+        newsService.delete("123abc");
 
-         //when(newsRepository.findById(news.getId())).thenReturn(Optional.of(news));
+        mockMvc.perform(MockMvcRequestBuilders.delete(URL + "/123abc")
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk());
 
-        mockMvc.perform(MockMvcRequestBuilders.delete("/news/{id}",20))
-               .andExpect(status().isOk());
 
-            /*RESULTADO: espera un 200 devuelve un 404*/
-
-             /*News news = new News();
-              newsRepository.delete(news);
-                 mockMvc.perform(delete(URL+"/" + news.getId()))
-                         .andExpect(status().isOk());*/
     }
 
     @Test
     @WithMockUser(username = "ADMIN", roles = {"ADMIN"})
     void delete_NotFound() throws Exception{
-        News news = new News();
-        news.setId("123abc");
+        String idNotFound = "456def";
+        newsService.delete("456def");
 
-        mockMvc.perform(MockMvcRequestBuilders.delete("/news/{id}", news.getId()))
+        mockMvc.perform(MockMvcRequestBuilders.delete(URL +idNotFound))
                 .andExpect(status().isNotFound());
 
-            //resultado: ok ???????????????
+    }
+
+    @Test
+    @WithMockUser(username = "ADMIN", roles = {"ADMIN"})
+    void delete_FailBecauseUserIsNotAdmin() throws Exception {
+        newsService.delete("123abc");
+
+        mockMvc.perform(MockMvcRequestBuilders.delete(URL + "/123abc")
+                        .contentType(APPLICATION_JSON)
+                        .with(user("user").roles("USER"))
+                        .with(csrf()))
+                .andExpect(status().isForbidden());
+
     }
 
 }

--- a/src/test/java/com/alkemy/ong/controller/NewsControllerTest.java
+++ b/src/test/java/com/alkemy/ong/controller/NewsControllerTest.java
@@ -1,20 +1,15 @@
 package com.alkemy.ong.controller;
-
 import com.alkemy.ong.dto.CategoryBasicDto;
 import com.alkemy.ong.dto.NewsDto;
-
 import com.alkemy.ong.entity.News;
 import com.alkemy.ong.repository.NewsRepository;
 import com.alkemy.ong.service.NewsService;
 import com.amazonaws.services.simplesystemsmanagement.model.ParameterNotFoundException;
-import com.amazonaws.services.simpleworkflow.flow.annotations.Workflow;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -22,41 +17,38 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
-
-
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.server.ResponseStatusException;
-
-
 import java.util.*;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
-
-
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
 @SpringBootTest
-@AutoConfigureMockMvc
-class NewsControllerTest{
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@TestPropertySource(locations = "")
+class NewsControllerTest {
 
 
     @Autowired
     private WebApplicationContext context;
 
-    @Autowired
+
     protected MockMvc mockMvc;
 
-    @Autowired
+    @MockBean
     private NewsRepository newsRepository;
 
     @MockBean
@@ -65,13 +57,15 @@ class NewsControllerTest{
     @Autowired
     ObjectMapper objectMapper;
 
+    @Autowired
+    private NewsController newsController;
+
     private News news;
     private NewsDto newsDto;
-    private List<CategoryBasicDto>categories = new ArrayList<CategoryBasicDto>();
+    private List<CategoryBasicDto> categories = new ArrayList<CategoryBasicDto>();
     private final static int PAGE = 0;
     private final static int SIZE = 2;
     private final String URL = "/news";
-
 
 
     @BeforeEach
@@ -115,7 +109,7 @@ class NewsControllerTest{
     @Test
     @WithMockUser(roles = "ADMIN")
     @DisplayName("Fail Saving News due to incomplete fields (Error 400 Bad Request)")
-    void createNews_BadRequest() throws Exception{
+    void createNews_BadRequest() throws Exception {
 
         newsDto.setName(null);
         mockMvc.perform(post(URL)
@@ -125,6 +119,7 @@ class NewsControllerTest{
 
 
     }
+
     @Test
     @WithMockUser(roles = "ADMIN")
     @DisplayName("Fail Saving News due to wrong role (Error 403 Forbidden)")
@@ -139,10 +134,19 @@ class NewsControllerTest{
 
     }
 
-    //GET//
+    @Test
+    @DisplayName("Fail Saving News because user is not authenticated (Error 401 Unauthorized)")
+    void createNews_FailBecauseUserIsAuthenticated() throws Exception {
+        mockMvc.perform(post(URL)
+                        .contentType(APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isUnauthorized());
+    }
+//GET//
 
     @Test
     @WithMockUser(roles = "ADMIN")
+    @DisplayName("Get News Success (Code 201 Created) with role ADMIN")
     void getNewsById_Ok() throws Exception {
         String id = "123abc";
         when(newsService.getNewsById(id)).thenReturn(newsDto);
@@ -155,40 +159,64 @@ class NewsControllerTest{
 
     @Test
     @WithMockUser(roles = "ADMIN")
-    void getNewsById_NotFound() throws Exception{
+    @DisplayName("Fail Getting News due to non-existent ID (Error 404 Not Found)")
+    void getNewsById_NotFound() throws Exception {
         String idNotFound = "456def";
 
-        when(newsService.getNewsById(idNotFound)).thenThrow((new ParameterNotFoundException("")));
-        mockMvc.perform(get(URL+idNotFound)
+        when(newsService.getNewsById(idNotFound)).thenThrow((new ResponseStatusException(HttpStatus.NOT_FOUND)));
+        mockMvc.perform(get(URL + "/" + idNotFound)
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(newsDto)))
                 .andExpect(status().isNotFound());
     }
 
     @Test
-    @WithMockUser(roles = "ADMIN")
+    @WithMockUser(roles = "USER")
+    @DisplayName("Get All News Pages: Success (Code 200 OK)")
     void getAllPage_Ok() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get(URL)
+                        .contentType(APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
 
-        Map<String, Object> response = new LinkedHashMap<>();
-        when(newsService.getAllPages(0)).thenReturn(response);
+    @Test
+    @WithMockUser(roles = "USER")
+    @DisplayName("Get All News Pages: Success (Code 200 OK)")
+    void getAllPage_Ok1() throws Exception {
 
-        mockMvc.perform(MockMvcRequestBuilders.get(URL+"/pages?page")
+         Map<String, Object> response = new LinkedHashMap<>();
+          when(newsService.getAllPages(1)).thenReturn(response);
+        mockMvc.perform(MockMvcRequestBuilders.get(URL + "?page=1")
                         .contentType(APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(response)))
+                .content(objectMapper.writeValueAsString(response)))
                 .andExpect(MockMvcResultMatchers.status().isOk());
 
     }
 
+
     @Test
     @WithMockUser(roles = "ADMIN")
-    void getAllPage_Forbidden()throws Exception{
+    @DisplayName("Fail Getting All News Pages (Code 500 Internal Server Error)")
+    void getAllPage_ServerError() throws Exception {
         Map<String, Object> response = new LinkedHashMap<>();
         when(newsService.getAllPages(0)).thenThrow(new Exception("Fail to load pages"));
 
-        mockMvc.perform(MockMvcRequestBuilders.get(URL+"/pages?page")
+        mockMvc.perform(MockMvcRequestBuilders.get(URL + "?page=0")
                         .contentType(APPLICATION_JSON))
                 .andExpect(MockMvcResultMatchers.status().is5xxServerError());
     }
+
+    @Test
+    @DisplayName("Fail Getting News because user is not authenticated (Error 401 Unauthorized)")
+    void getNews_FailBecauseUserIsAuthenticated() throws Exception {
+        String id = "123abc";
+        when(newsService.getNewsById(id)).thenReturn(newsDto);
+
+        mockMvc.perform(get("/news/{id}", id)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+    }
+
 
     //PUT//
 
@@ -199,34 +227,32 @@ class NewsControllerTest{
         String id = "123abc";
 
         when(newsService.updateNews("123abc", newsDto)).thenReturn(newsDto);
-        mockMvc.perform(put(URL+"/123abc")
+        mockMvc.perform(put(URL + "/123abc")
                         .contentType(APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(newsDto))
                         .with(user("admin").roles("ADMIN"))
                         .with(csrf()))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.name").value("name"))
-                .andExpect(jsonPath("$.image").value("image"))
-                .andExpect(jsonPath("$.content").value("content"));
-    }
+                .andExpect(status().isOk());
 
+    }
     @Test
     @WithMockUser(roles = "ADMIN")
     @DisplayName("Fail Updating News due to non-existent ID (Error 404 Not Found)")
-    void updateNews_NotFoundById() throws Exception{
+    void updateNews_NotFoundById() throws Exception {
         String idNotFound = "456def";
-        when(newsService.updateNews(idNotFound, newsDto)).thenThrow((new ParameterNotFoundException("")));
-        mockMvc.perform(put(URL+idNotFound)
-                        .contentType(APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(newsDto)))
-                .andExpect(status().isNotFound());
+        newsDto.setName("New name");
 
+        when(newsService.updateNews(idNotFound, newsDto)).thenThrow(new ParameterNotFoundException(""));
+
+        mockMvc.perform(put(URL + idNotFound)
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isNotFound());
     }
 
     @Test
     @WithMockUser(roles = "ADMIN")
     @DisplayName("Fail Updating News due to incorrect role (Error 403 Forbidden)")
-    void updateNews_FailBecauseUserIsNotAdmin() throws Exception{
+    void updateNews_FailBecauseUserIsNotAdmin() throws Exception {
         when(newsService.updateNews("123abc", newsDto)).thenReturn(newsDto);
         mockMvc.perform(put(URL + "/123abc")
                         .contentType(APPLICATION_JSON)
@@ -238,9 +264,9 @@ class NewsControllerTest{
     }
 
     @Test
-    @WithMockUser(roles= "ADMIN")
+    @WithMockUser(roles = "ADMIN")
     @DisplayName("Fail Updating News due to incomplete fields (Error 400 Bad Request)")
-    void updateNews_BadRequest() throws Exception{
+    void updateNews_BadRequest() throws Exception {
         newsDto.setName(null);
         newsDto.setImage(null);
         newsDto.setContent(null);
@@ -253,7 +279,15 @@ class NewsControllerTest{
                 .andExpect(status().isBadRequest());
 
     }
+    @Test
+    @DisplayName("Fail Updating News because user is not authenticated (Error 401 Unauthorized)")
+    void updateNews_FailBecauseUserIsNotAuthenticated() throws Exception {
 
+        mockMvc.perform(put(URL+"/123abc")
+                        .contentType(APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isUnauthorized());
+    }
 
 
     //DELETE//
@@ -261,7 +295,7 @@ class NewsControllerTest{
     @Test
     @WithMockUser(roles = "ADMIN")
     @DisplayName("Delete News: Success (Code 200 OK)")
-    void delete_Ok() throws Exception{
+    void delete_Ok() throws Exception {
         newsService.delete("123abc");
 
         mockMvc.perform(MockMvcRequestBuilders.delete(URL + "/123abc")
@@ -274,11 +308,11 @@ class NewsControllerTest{
     @Test
     @WithMockUser(roles = "ADMIN")
     @DisplayName("Fail Deleting News due to non-existent ID (Error 404 Not Found)")
-    void delete_NotFound() throws Exception{
+    void delete_NotFound() throws Exception {
         String idNotFound = "456def";
         newsService.delete("456def");
 
-        mockMvc.perform(MockMvcRequestBuilders.delete(URL +idNotFound))
+        mockMvc.perform(MockMvcRequestBuilders.delete(URL + idNotFound))
                 .andExpect(status().isNotFound());
 
     }
@@ -297,4 +331,14 @@ class NewsControllerTest{
 
     }
 
+    @Test
+    @DisplayName("Fail Deleting News because user is not authenticated (Error 401 Unauthorized)")
+    void deleteNews_FailBecauseUserIsNotAuthenticated() throws Exception {
+        newsService.delete("abc123");
+        mockMvc.perform(delete(URL + "/123abc")
+                        .contentType(APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isUnauthorized());
+
+    }
 }


### PR DESCRIPTION
Se realizaron 19 tests correspondientes a los endpoints de News: POST, GET, PUT y DELETE.

//POST// Create news

- Save News Success (Code 201 Created) with role ADMIN
- Fail Saving News due to incomplete fields (Error 400 Bad Request
- Fail Saving News due to wrong role (Error 403 Forbidden)
- Fail Saving News because user is not authenticated (Error 401 Unauthorized)

//GET// Get news

- Get News Success (Code 201 Created) with role ADMIN
- Fail Getting News due to non-existent ID (Error 404 Not Found)
- Get All News Pages: Success (Code 200 OK) (PAGE 0)
-  Get All News Pages: Success (Code 200 OK) (PAGE 1)
- Fail Getting All News Pages (Code 500 Internal Server Error)
- Fail Getting News because user is not authenticated (Error 401 Unauthorized)

//POST// Update News

- Update News: Success (Code 200 OK)
- Fail Updating News due to non-existent ID (Error 404 Not Found)
- Fail Updating News due to incorrect role (Error 403 Forbidden)
- Fail Updating News due to incomplete fields (Error 400 Bad Request)
- Fail Updating News because user is not authenticated (Error 401 Unauthorized)

//DELETE// Delete News

- Delete News: Success (Code 200 OK)
- Fail Deleting News due to non-existent ID (Error 404 Not Found)
- Fail Deleting News due to incorrect user role (Error 403 Forbidden)
- Fail Deleting News because user is not authenticated (Error 401 Unauthorized)


