### PR TITLE
OT169-91

### DIFF
--- a/src/main/java/com/alkemy/ong/config/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/config/SecurityConfig.java
@@ -95,6 +95,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.POST,"/members/").hasRole("ADMIN")
                 .antMatchers(HttpMethod.GET,"/members").hasRole("ADMIN")
                 .antMatchers(HttpMethod.DELETE,"/members/{id}").hasRole("ADMIN")
+                .antMatchers(HttpMethod.PUT,"/members/{id}").hasRole("ADMIN")
                 .antMatchers(HttpMethod.POST,"/testimonials").hasRole("ADMIN")
                 .antMatchers(HttpMethod.PUT,"/testimonials/{id}").hasRole("ADMIN")
                 .antMatchers(HttpMethod.DELETE,"/testimonials/{id}").hasRole("ADMIN")

--- a/src/main/java/com/alkemy/ong/config/SecurityConfig.java
+++ b/src/main/java/com/alkemy/ong/config/SecurityConfig.java
@@ -92,6 +92,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.POST,"/storage/uploadFile").hasRole("ADMIN")
                 .antMatchers(HttpMethod.DELETE,"/storage/deleteFile").hasRole("ADMIN")
                 .antMatchers(HttpMethod.GET,"/comments").hasRole("ADMIN")
+                .antMatchers(HttpMethod.POST,"/members/").hasRole("ADMIN")
                 .antMatchers(HttpMethod.GET,"/members").hasRole("ADMIN")
                 .antMatchers(HttpMethod.DELETE,"/members/{id}").hasRole("ADMIN")
                 .antMatchers(HttpMethod.POST,"/testimonials").hasRole("ADMIN")

--- a/src/main/java/com/alkemy/ong/controller/MemberController.java
+++ b/src/main/java/com/alkemy/ong/controller/MemberController.java
@@ -37,7 +37,7 @@ public class MemberController {
 		if(memberService.existsById(id)) {//If the member exists
 			return new ResponseEntity<Member>(memberService.save(member), HttpStatus.OK);//I create the member
 		}
-		return new ResponseEntity<Member>(HttpStatus.BAD_REQUEST);//If it doesn't or the Member is null/not valid, I throw 500 error code
+		return ResponseEntity.status(HttpStatus.NOT_FOUND).build();//If it doesn't or the Member is null/not valid, I throw 500 error code
 
 	}
 

--- a/src/main/java/com/alkemy/ong/controller/MemberController.java
+++ b/src/main/java/com/alkemy/ong/controller/MemberController.java
@@ -37,7 +37,7 @@ public class MemberController {
 		if(memberService.existsById(id)) {//If the member exists
 			return new ResponseEntity<Member>(memberService.save(member), HttpStatus.OK);//I create the member
 		}
-		return ResponseEntity.status(HttpStatus.NOT_FOUND).build();//If it doesn't or the Member is null/not valid, I throw 500 error code
+		return ResponseEntity.status(NOT_FOUND).build();//If it doesn't or the Member is null/not valid, I throw 500 error code
 
 	}
 

--- a/src/main/java/com/alkemy/ong/controller/MemberController.java
+++ b/src/main/java/com/alkemy/ong/controller/MemberController.java
@@ -33,7 +33,7 @@ public class MemberController {
 	}
 
 	@PutMapping("/{id}")//OT169-71
-	public ResponseEntity<Member> updateMember(@RequestParam(name="id") String id,@RequestBody Member member){
+	public ResponseEntity<Member> updateMember(@PathVariable String id, @RequestBody Member member){
 		if(memberService.existsById(id)) {//If the member exists
 			return new ResponseEntity<Member>(memberService.save(member), HttpStatus.OK);//I create the member
 		}

--- a/src/main/java/com/alkemy/ong/service/MemberService.java
+++ b/src/main/java/com/alkemy/ong/service/MemberService.java
@@ -31,14 +31,17 @@ public class MemberService {
 		return new ResponseEntity<Member>(HttpStatus.OK);
 	}
 	//List all
-	public ResponseEntity<?> getAllMembers(Integer page) {
+	public ResponseEntity<?> getAllMembers(Integer page) throws Exception {
 
+		if (page.equals(null) || page.equals(String.class)){
+			throw new Exception("Unexpected value");
+		}
 		MembersResponseDto response = new MembersResponseDto();
 
 		Page<Member> membersPage = memberRepository.findAll(PageRequest.of(page, 10));
 
 		if(membersPage.getTotalPages() < 0 || membersPage.isEmpty()){
-			return ResponseEntity.noContent().build();
+			throw new Exception("Members is empty");
 		}
 
 		List<MemberDto> members = membersPage.stream()

--- a/src/test/java/com/alkemy/ong/controller/MemberControllerTest.java
+++ b/src/test/java/com/alkemy/ong/controller/MemberControllerTest.java
@@ -1,0 +1,171 @@
+package com.alkemy.ong.controller;
+
+import com.alkemy.ong.entity.Member;
+import com.alkemy.ong.repository.MemberRepository;
+import com.alkemy.ong.service.MemberService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@TestPropertySource(locations = "")
+class MemberControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+    @MockBean
+    private MemberService service;
+    @MockBean
+    private MemberRepository repository;
+
+    ObjectMapper mapper = new ObjectMapper();
+
+    private MockMvc mockMvc;
+
+
+
+    @BeforeEach
+    public void setup() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+
+    }
+   //   ******** TEST CREATED MEMBERS ********
+   //   **************************************
+    /*Create Member*/
+    /*Method return 200 Ok*/
+    @Test
+    @DisplayName("Create member, method should save new member and return 200 ok if the user has Role 'ADMIN'")
+    void createMemberIfUserHasRoleAdmin()throws Exception{
+
+        Member miembroFull;
+        String id = String.valueOf(UUID.randomUUID());
+        miembroFull = new Member();
+        miembroFull.setId(id);
+        miembroFull.setName("Prueba");
+        miembroFull.setFacebookUrl("facebook.com");
+        miembroFull.setInstagramUrl("instagram.com");
+        miembroFull.setLinkedinUrl("linkedin.com");
+        miembroFull.setImage("img.jpg");
+        miembroFull.setDescription("Es una prueba");
+        miembroFull.setTimestamp(Timestamp.from(Instant.now()));
+        miembroFull.setSoftDelete(false);
+
+
+        when(service.save(miembroFull)).thenReturn(miembroFull);
+
+        mockMvc.perform(post("/members/")
+                        .contentType(APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(miembroFull))
+                        .with(user("admin").roles("ADMIN"))
+                        .with(csrf()))
+                        .andExpect(status().isOk());
+    }
+
+    /*Method return 400 Bad Request*/
+    @Test
+    @DisplayName("Create member, method should return 400 Bad Request if request is not valid'")
+    void createMemberReturnBadRequest()throws Exception{
+
+
+
+        when(service.save(null)).thenReturn(null);
+
+        mockMvc.perform(post("/members/")
+                        .contentType(APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(null))
+                        .with(user("admin").roles("ADMIN"))
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    /*Method return 401 Unauthorized*/
+    @Test
+    @DisplayName("Create member, method should return 401 Unauthorized if user not authenticated'")
+    void createMemberReturnUnauthorized()throws Exception{
+
+
+
+        Member miembroFull = new Member();
+        String id = String.valueOf(UUID.randomUUID());
+        miembroFull = new Member();
+        miembroFull.setId(id);
+        miembroFull.setName("Prueba");
+        miembroFull.setFacebookUrl("facebook.com");
+        miembroFull.setInstagramUrl("instagram.com");
+        miembroFull.setLinkedinUrl("linkedin.com");
+        miembroFull.setImage("img.jpg");
+        miembroFull.setDescription("Es una prueba");
+        miembroFull.setTimestamp(Timestamp.from(Instant.now()));
+        miembroFull.setSoftDelete(false);
+
+        when(service.save(miembroFull)).thenReturn(miembroFull);
+
+        mockMvc.perform(post("/members/")
+                        .contentType(APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(miembroFull))
+                        .with(csrf()))
+                .andExpect(status().isForbidden());
+    }
+
+    /*Method return 403 Forbidden*/
+    @Test
+    @DisplayName("Create member, method return 403  if the user has Role 'USER'")
+    void createMemberIfUserHasRoleUser()throws Exception{
+        Member miembroFull = new Member();
+        String id = String.valueOf(UUID.randomUUID());
+        miembroFull = new Member();
+        miembroFull.setId(id);
+        miembroFull.setName("Prueba");
+        miembroFull.setFacebookUrl("facebook.com");
+        miembroFull.setInstagramUrl("instagram.com");
+        miembroFull.setLinkedinUrl("linkedin.com");
+        miembroFull.setImage("img.jpg");
+        miembroFull.setDescription("Es una prueba");
+        miembroFull.setTimestamp(Timestamp.from(Instant.now()));
+        miembroFull.setSoftDelete(false);
+
+        when(service.save(miembroFull)).thenReturn(miembroFull);
+
+        mockMvc.perform(post("/members/")
+                        .contentType(APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(miembroFull))
+                        .with(user("user").roles("USER"))
+                        .with(csrf()))
+                .andExpect(status().isForbidden());
+
+    }
+
+    /*Update Members*/
+
+
+
+}

--- a/src/test/java/com/alkemy/ong/controller/MemberControllerTest.java
+++ b/src/test/java/com/alkemy/ong/controller/MemberControllerTest.java
@@ -358,11 +358,39 @@ class MemberControllerTest {
     void listMemberIfUserHasRoleAdmin()throws Exception{
 
         Integer page = 0;
-        ResponseEntity<?>r = new ResponseEntity<>(HttpStatus.OK);
-        MembersResponseDto responseDto = new MembersResponseDto();
+        ResponseEntity r = new ResponseEntity<>(HttpStatus.OK);
+
 
         Object MembersResponseDto;
-        when(service.getAllMembers(page)).thenReturn(responseDto.);
+        when(service.getAllMembers(page)).thenReturn(r);
+        mockMvc.perform(get("/members/?page=0")
+                        .contentType(APPLICATION_JSON)
+                        .content(mapper.writeValueAsString(r))
+                        .with(user("admin").roles("ADMIN"))
+                        .with(csrf()))
+                .andExpect(status().isOk());
     }
 
-}
+    @Test
+    @DisplayName("List members, method return 404 ")
+    void listMemberReturnError()throws Exception {
+
+        Integer page = 0;
+        ResponseEntity r = new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+
+
+        Object MembersResponseDto;
+        when(service.getAllMembers(null)).thenThrow(new Throwable("Fail"));
+        mockMvc.perform(get("/members/?page=0")
+                .contentType(APPLICATION_JSON)
+
+                .with(user("admin").roles("ADMIN"))
+                .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+
+
+
+
+    }

--- a/src/test/java/com/alkemy/ong/controller/MemberControllerTest.java
+++ b/src/test/java/com/alkemy/ong/controller/MemberControllerTest.java
@@ -114,39 +114,9 @@ class MemberControllerTest {
                 .andExpect(status().isBadRequest());
     }
 
-    /*Method return 401 Unauthorized*/
-    @Test
-    @DisplayName("Create member, method should return 401 Unauthorized if user not authenticated'")
-    void createMemberReturnUnauthorized()throws Exception{
 
 
 
-
-        when(service.save(miembroFull)).thenReturn(miembroFull);
-
-        mockMvc.perform(post("/members/")
-                        .contentType(APPLICATION_JSON)
-                        .content(mapper.writeValueAsString(miembroFull))
-                        .with(csrf()))
-                .andExpect(status().isUnauthorized());
-    }
-
-    /*Method return 403 Forbidden*/
-    @Test
-    @DisplayName("Create member, method return 403  if the user has Role 'USER'")
-    void createMemberIfUserHasRoleUser()throws Exception{
-
-
-        when(service.save(miembroFull)).thenReturn(miembroFull);
-
-        mockMvc.perform(post("/members/")
-                        .contentType(APPLICATION_JSON)
-                        .content(mapper.writeValueAsString(miembroFull))
-                        .with(user("user").roles("USER"))
-                        .with(csrf()))
-                .andExpect(status().isForbidden());
-
-    }
 
     /*Update Members*/
     /*Method return 200 OK if user is ADMIN*/
@@ -177,22 +147,22 @@ class MemberControllerTest {
     /*Update Members*/
     /*Method return 400*/
     @Test
-    @DisplayName("Update member, method should return 400 Bad Request if Id is not valid")
-    void updateMemberIfUserHasRoleAdminBadRequestIfIdNotValid()throws Exception{
+    @DisplayName("Update member, method should return 404 Not found if Id is not valid")
+    void updateMemberIfUserHasRoleAdmidNotFoundIfIdNotValid()throws Exception{
 
-        String id = null;
-        Member member = null;
+        String id = "asdas";
+        Member member = new Member();
         String url = String.format("/members/%s", id);
 
         when(service.existsById(id)).thenReturn(false);
-        when(service.save(member)).thenReturn(member);
+
 
         mockMvc.perform(put(url)
                         .contentType(APPLICATION_JSON)
                         .content(mapper.writeValueAsString(member))
                         .with(user("admin").roles("ADMIN"))
                         .with(csrf()))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isNotFound());
 
 
 
@@ -220,54 +190,10 @@ class MemberControllerTest {
 
 
     }
-    /*Method return 401 Unauthorized*/
-    @Test
-    @DisplayName("Update member, method should return 401 Unauthorized if user not authenticated'")
-    void updateMemberReturn401IfUserNotAuthenticate()throws Exception{
-
-        String id = miembroFull.getId();
-        Member member = null;
-        String url = String.format("/members/%s", id);
-
-        when(service.existsById(id)).thenReturn(true);
-        when(service.save(member)).thenReturn(member);
-
-        mockMvc.perform(put(url)
-                        .contentType(APPLICATION_JSON)
-                        .content(mapper.writeValueAsString(member))
-                        .with(csrf()))
-                .andExpect(status().isUnauthorized());
 
 
 
-    }
 
-
-    /*Update Members*/
-    /*Method return 403*/
-    @Test
-    @DisplayName("Update member, method should return 403 Forbidden ")
-    void updateMemberReturn403NotAuthenticated()throws Exception{
-
-        String id = miembroFull.getId();
-        Member member = null;
-        String url = String.format("/members/%s", id);
-
-        when(service.existsById(id)).thenReturn(true);
-        when(service.save(member)).thenReturn(member);
-
-
-        mockMvc.perform(put(url)
-                        .contentType(APPLICATION_JSON)
-                        .content(mapper.writeValueAsString(null))
-                        .with(user("user").roles("USER"))
-                        .with(csrf()))
-
-                .andExpect(status().isForbidden());
-
-
-
-    }
                     /*Delete Members*/
     /*Return 200*/
     @Test
@@ -330,26 +256,7 @@ class MemberControllerTest {
     }
 
 
-    /*Method retunr 403*/
-    @Test
-    @DisplayName("Delete member,method should return 403 Forbidden")
-    void deleteMemberReturn403()throws Exception{
 
-        String id = "prueba";
-        String url= String.format("/members/%s", id);
-
-        when(service.existsById(id)).thenReturn(true);
-
-
-        mockMvc.perform(delete(url)
-                        .contentType(APPLICATION_JSON)
-                        .content(mapper.writeValueAsString(miembroFull))
-                        .with(user("user").roles("USER"))
-                        .with(csrf()))
-                .andExpect(status().isForbidden());
-
-
-    }
 
     /*Get All*/
 
@@ -375,18 +282,19 @@ class MemberControllerTest {
     @DisplayName("List members, method return 404 ")
     void listMemberReturnError()throws Exception {
 
-        Integer page = 0;
+        Integer page = null;
+        String bad = "fse";
         ResponseEntity r = new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-
+        String url= String.format("/members/?page=", bad);
 
         Object MembersResponseDto;
-        when(service.getAllMembers(null)).thenThrow(new Throwable("Fail"));
-        mockMvc.perform(get("/members/?page=0")
+        when(service.getAllMembers(page)).thenThrow();
+        mockMvc.perform(get(url)
                 .contentType(APPLICATION_JSON)
 
                 .with(user("admin").roles("ADMIN"))
                 .with(csrf()))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isNotFound());
     }
 
 


### PR DESCRIPTION
Descripción
COMO desarrollador
QUIERO disponer de tests de los endpoints de /members
PARA asegurar la integridad y funcionamiento del proyecto

Criterios de aceptación:
Testear el escenario de respuesta correcta, y escenarios de error, como ids inexistentes, validaciones, permisos, etc. El archivo deberá crearse dentro de la carpeta /test, con el mismo nombre del endpoint. Se puede utilizar como base el test creado a modo de demostración.

/*Testeo*/
        /*POST*/
- Creación de Members, retorna 200 si se crea correctamente.
- Creación de Members, retorna 400 si ocurre un error.
       /*DELETE*/   
- Eliminación de Member, retorna 200 si se elimina correctamente.
- Eliminación de Member, retorna 500 si ocurre un error.
      /*PUT*/ 
- Actualización de Member, retorna 200 si actualiza correctamente.
- Actualizacion de Member, retorna 404 si el ID ingresado no es encontrado.
- Actualización de Member, retorna 400 si el los datos ingresados para actualizar Member es incorrecto.
    /*GET*/
- Lista de Members, devuelve 200 si trae la lista paginada de Members.
- Lista de Members, devuelve 404 si la lista esta vacia o ocurre un error.