### PR TITLE
OT169-96 Test Auth Controller Endpoint

### DIFF
--- a/src/main/java/com/alkemy/ong/controller/MemberController.java
+++ b/src/main/java/com/alkemy/ong/controller/MemberController.java
@@ -69,10 +69,6 @@ public class MemberController {
 		return new ResponseEntity<Member>(HttpStatus.INTERNAL_SERVER_ERROR);//If the member doesn't exists, throws 500 error code
 	}
 
-
-	@PutMapping("/{id}")//OT169-71
-	public ResponseEntity<Member> updateMember(@PathVariable String id, @RequestBody Member member){
-
 	@PutMapping(value = "/{id}", produces = {"application/json"}, consumes = {"application/json"})
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	@ApiOperation(value = "Update a member passed by id.")

--- a/src/test/java/com/alkemy/ong/controller/AuthControllerTest.java
+++ b/src/test/java/com/alkemy/ong/controller/AuthControllerTest.java
@@ -1,0 +1,96 @@
+package com.alkemy.ong.controller;
+
+import com.alkemy.ong.dto.UserCredentialsDto;
+import com.alkemy.ong.service.impl.UserDetailsCustomServiceImpl;
+import com.alkemy.ong.utils.JwtUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.Collections;
+
+import static com.alkemy.ong.controller.ActivitiesTest.asJson;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class AuthControllerTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    private UserCredentialsDto userCredentialsDto;
+
+    private User user;
+
+    private String jwt;
+
+    @Autowired
+    JwtUtils jwtUtil;
+
+    @MockBean
+    private UserDetailsCustomServiceImpl userDetailsCustomService;
+
+    @MockBean
+    AuthenticationManager authenticationManager;
+
+    @MockBean
+    private UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken;
+
+    private final String commonUrl = "/auth";
+
+    @BeforeEach
+    public void setup(){
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+
+        userCredentialsDto = new UserCredentialsDto();
+        userCredentialsDto.setEmail("eva@mail.com");
+        userCredentialsDto.setPassword("1234");
+
+        user = new User("eva@mail.com","1234", Collections.singletonList(new SimpleGrantedAuthority("ROLE_ADMIN")));
+        jwt = jwtUtil.generateToken(user);
+
+    }
+
+
+    @Test
+    @DisplayName("Login user with its credentianls and should return a 200 an a authentication response with the jwt")
+    void logiUser__ShouldLoginUserAndReturnOkAndJwt() throws Exception{
+
+        usernamePasswordAuthenticationToken.setDetails(userCredentialsDto);
+
+        when(userDetailsCustomService.loadUserByUsername(userCredentialsDto.getEmail())).thenReturn(user);
+        when(usernamePasswordAuthenticationToken.isAuthenticated()).thenReturn(true);
+        when(authenticationManager.authenticate(any())).thenReturn(any());
+
+        mockMvc.perform(post(commonUrl +"/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJson(userCredentialsDto)))
+                .andExpect(status().isOk())
+                .andExpect((jsonPath("$.jwt").value(jwt)));
+    }
+
+
+}

--- a/src/test/java/com/alkemy/ong/controller/AuthControllerTest.java
+++ b/src/test/java/com/alkemy/ong/controller/AuthControllerTest.java
@@ -1,6 +1,13 @@
 package com.alkemy.ong.controller;
 
+import com.alkemy.ong.config.SwaggerConfig;
 import com.alkemy.ong.dto.UserCredentialsDto;
+import com.alkemy.ong.dto.UserDto;
+import com.alkemy.ong.entity.Role;
+import com.alkemy.ong.filter.JwtRequestFilter;
+import com.alkemy.ong.repository.RoleRepository;
+import com.alkemy.ong.repository.UserRepository;
+import com.alkemy.ong.service.EmailService;
 import com.alkemy.ong.service.impl.UserDetailsCustomServiceImpl;
 import com.alkemy.ong.utils.JwtUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,29 +16,39 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import javax.servlet.http.HttpServletRequest;
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Collections;
+import java.util.Optional;
 
 import static com.alkemy.ong.controller.ActivitiesTest.asJson;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@TestPropertySource(locations = "")
 public class AuthControllerTest {
 
     @Autowired
@@ -43,6 +60,12 @@ public class AuthControllerTest {
 
     private User user;
 
+    private com.alkemy.ong.entity.User userEntity;
+
+    private Role roleEntity;
+
+    private UserDto userDto;
+
     private String jwt;
 
     @Autowired
@@ -52,7 +75,19 @@ public class AuthControllerTest {
     private UserDetailsCustomServiceImpl userDetailsCustomService;
 
     @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private RoleRepository roleRepository;
+
+    @MockBean
+    private EmailService emailService;
+
+    @MockBean
     AuthenticationManager authenticationManager;
+
+    @MockBean
+    HttpServletRequest httpServletRequest;
 
     @MockBean
     private UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken;
@@ -72,12 +107,34 @@ public class AuthControllerTest {
         user = new User("eva@mail.com","1234", Collections.singletonList(new SimpleGrantedAuthority("ROLE_ADMIN")));
         jwt = jwtUtil.generateToken(user);
 
+        userDto = new UserDto();
+        userDto.setFirstName("Maria Eva");
+        userDto.setLastName("De los angeles");
+        userDto.setPhoto("eva.jpg");
+        userDto.setEmail("eva@mail.com");
+
+        roleEntity = new Role();
+        roleEntity.setId("1");
+        roleEntity.setDescription("Role with administrator privileges");
+        roleEntity.setName("ADMIN");
+
+        userEntity = new com.alkemy.ong.entity.User();
+        userEntity.setId("10");
+        userEntity.setEmail("eva@mail.com");
+        userEntity.setPhoto("eva.jpg");
+        userEntity.setFirstName("Maria Eva");
+        userEntity.setLastName("De los angeles");
+        userEntity.setPassword("1234");
+        userEntity.setRoleId(roleEntity);
     }
 
+    /*==================================
+            TEST FOR USER LOGIN
+     ===================================*/
 
     @Test
-    @DisplayName("Login user with its credentianls and should return a 200 an a authentication response with the jwt")
-    void logiUser__ShouldLoginUserAndReturnOkAndJwt() throws Exception{
+    @DisplayName("User login with correct credentials and should return a 200 an a authentication response with the jwt")
+    void loginUser__ShouldLoginUserAndReturnOkAndJwt() throws Exception{
 
         usernamePasswordAuthenticationToken.setDetails(userCredentialsDto);
 
@@ -92,5 +149,86 @@ public class AuthControllerTest {
                 .andExpect((jsonPath("$.jwt").value(jwt)));
     }
 
+    @Test
+    @DisplayName("User login with incorrect credentials and should return a 400 bad request")
+    void userLogin__shouldReturnBadRequestIfUserCredentialsAreIncorrect() throws Exception{
 
+        userCredentialsDto.setEmail("");
+
+        when(userDetailsCustomService.loadUserByUsername(userCredentialsDto.getEmail())).thenThrow(new BadCredentialsException("Incorrect email or password"));
+
+        mockMvc.perform(post(commonUrl + "/login")
+               .contentType(MediaType.APPLICATION_JSON)
+               .content(asJson(userCredentialsDto)))
+               .andExpect(status().isBadRequest());
+    }
+
+    /*================================================================
+            TEST FOR THE AUTHENTICATED USER TO OBTAIN THEIR DATA
+      ================================================================*/
+
+    @Test
+    @DisplayName("Get authenticated user data should return 200 ok and return user data")
+    @WithMockUser(username = "eva@mail.com",password = "1234",roles = "ADMIN")
+    void getAuthenticatedUserData__shouldReturnOkAndUserData() throws Exception{
+
+        when(userRepository.findByEmail(userDto.getEmail())).thenReturn(userEntity);
+        when(usernamePasswordAuthenticationToken.isAuthenticated()).thenReturn(true);
+
+        mockMvc.perform(get(commonUrl + "/me").header(HttpHeaders.AUTHORIZATION,"Bearer "+jwt)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.firstName").value("Maria Eva"))
+                .andExpect(jsonPath("$.lastName").value("De los angeles"))
+                .andExpect(jsonPath("$.email").value("eva@mail.com"))
+                .andExpect(jsonPath("$.photo").value("eva.jpg"));
+    }
+
+    @Test
+    @DisplayName("Get authneticated user data should return 401 Unauthorized if a valid JWT is missing in the request or user is not logged in")
+    @WithMockUser(username = "eva@mail.com",password = "1234",roles = "ADMIN")
+    void getAuthenticatedUserData__shouldReturn401UnauthorizedIfAValidJwtIsMissing() throws Exception{
+
+        mockMvc.perform(get(commonUrl + "/me").header(HttpHeaders.AUTHORIZATION,jwt))
+                .andExpect(status().isUnauthorized());
+    }
+
+    /*=======================================
+            TEST FOR REGISTER AN USER
+      =======================================*/
+
+    @Test
+    @DisplayName("Register new user should return 200 ok and the jwt in the authentication response")
+    void registerUser__shouldReturn200OkAndJwt() throws Exception{
+
+        when(userRepository.save(userEntity)).thenReturn(null);
+        when(roleRepository.findById(roleEntity.getId())).thenReturn(Optional.of(roleEntity));
+        when(userDetailsCustomService.loadUserByUsername(userEntity.getEmail())).thenReturn(user);
+        when(usernamePasswordAuthenticationToken.isAuthenticated()).thenReturn(true);
+        when(authenticationManager.authenticate(any())).thenReturn(any());
+
+        mockMvc.perform(post(commonUrl +"/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(asJson(userEntity)))
+                .andExpect(status().isOk())
+                .andExpect((jsonPath("$.jwt").value(jwt)));
+    }
+
+    @Test
+    @DisplayName("Register new user should return 400 bad request if request is not valid")
+    void registerUser__shouldReturn400BadRequestIfRequestIsNotValid() throws Exception{
+
+        userEntity.setFirstName(null);
+
+        when(userRepository.save(userEntity)).thenReturn(null);
+        when(roleRepository.findById(roleEntity.getId())).thenReturn(Optional.of(roleEntity));
+        when(userDetailsCustomService.loadUserByUsername(userEntity.getEmail())).thenReturn(user);
+        when(usernamePasswordAuthenticationToken.isAuthenticated()).thenReturn(true);
+        when(authenticationManager.authenticate(any())).thenReturn(any());
+
+        mockMvc.perform(post(commonUrl +"/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJson(userEntity)))
+                .andExpect(status().isBadRequest());
+    }
 }


### PR DESCRIPTION
COMO desarrollador
QUIERO disponer de tests de los endpoints de /authentication
PARA asegurar la integridad y funcionamiento del proyecto

Criterios de aceptación:
Testear el escenario de respuesta correcta, y escenarios de error, como ids inexistentes, validaciones, permisos, etc. El archivo deberá crearse dentro de la carpeta /test, con el mismo nombre del endpoint. Se puede utilizar como base el test creado a modo de demostración.

***TEST REALIZADOS***

->LOGIN DE USUARIOS
*Se testeo que loguee al usuario y devuelva un 200 ok y el jwt si las credenciales son correctas
*Se testo que cuando el usuario se quiera logear y pase alguna credencial incorrecta, devuelva un 400 BadRequest

->OBTENER DATOS DEL USUARIO AUTENTICADO
*Se testeo que el usuario mande un jwt valido para autenticarse, y devuelva un 200 OK y los datos del usuario
*Se testeo que cuando el usuario no envié un jwt valido para autenticarse, devuelva un 401 Unauthorized

->REGISTRO DE USUARIO
*Se testeo que el usuario se registre correctamente y devuelva un 200 OK junto con el jwt.
*Se testeo que cuando el usuario mande las credenciales para registrarse y el email ya exista, devuelva un 409 Conflict
*Se testeo que cuando el usuario mande las credenciales para registrase incorrectas, devuelva un 400 Bad Request

![image](https://user-images.githubusercontent.com/64873359/163741669-55ec17b9-a9a1-415e-9dee-f3b98356208f.png)


***SE CORRIGIO EN EL MEMBER CONTROLLER LINEAS DUPLICADAS*****